### PR TITLE
add ubuntu docker installation tutorial

### DIFF
--- a/community-tutorials/ubuntu-docker-install/01-en.md
+++ b/community-tutorials/ubuntu-docker-install/01-en.md
@@ -202,7 +202,7 @@ sudo ufw-docker install
 
 To publish a containers port use the command:
 ```bash
-sudo ufw-docker allow CONTAINER_NAME PORT
+sudo ufw-docker allow <CONTAINER_NAME> <PORT>
 ```
 
 Further information and help can be shown by using:

--- a/community-tutorials/ubuntu-docker-install/01-en.md
+++ b/community-tutorials/ubuntu-docker-install/01-en.md
@@ -1,6 +1,6 @@
 ---
-title: Install Docker-CE on Ubuntu 20.04 with docker-compose, portainer and ufw
-description: How to setup Docker-CE on Ubuntu 20.04 with docker-compose and portainer for better management. Additional ufw configuration instructions for additional security
+title: Installing Docker CE on Ubuntu 20.04 with docker-compose, Portainer and ufw
+description: Learn how to set up Docker CE on Ubuntu 20.04 with docker-compose and Portainer for better management. Includes ufw configuration instructions for additional security.
 updated_at: 2021-11-04
 slug: ubuntu-docker-install-with-compose-and-portainer
 author_name: Marcel Aust
@@ -14,23 +14,27 @@ available_languages: en
 ---
 
 # Introduction
-This tutorial explains how to install Docker-CE on Ubuntu 20.04.
-With this tutorial you will learn how to install and configure Docker on Ubuntu to use it with many different apps and services.
-In addition this tutorial describes how to use Docker with **ufw** and additionally install and setup **docker-compose** and **portainer**.
-You should have a basic understanding of linux and shell commands. A fresh install of Ubuntu 20.04 (may work with other versions too) is required.
 
-This tutorial is based on the [offical tutorial provided by docker](https://docs.docker.com/engine/install/ubuntu/) with a few extra notes and additions.
+This tutorial explains how to install Docker CE on Ubuntu 20.04.
+With this tutorial, you will learn how to install and configure Docker on Ubuntu to use it with many different apps and services.
+Also, this tutorial describes how to use Docker with **ufw** and additionally install and set up **docker-compose** and **Portainer**.
+You should have a basic understanding of Linux and shell commands. A fresh install of Ubuntu 20.04 (may also work with other versions) is required.
+
+This tutorial is based on the [official tutorial provided by docker](https://docs.docker.com/engine/install/ubuntu/) with a few extra notes and additions.
 
 # Requirements
-Docker can be used on nearly any Root- or V-Server. Netcups server's architecture is amd64. You need to be root and/or have sudo privileges to install packages.
 
-# Step 1 - (Preparation)
-We will install Docker by using Ubuntus APT package manager. To fetch the latest package database, use:
+Docker can be used on nearly any root or vServer. netcup's server architecture is amd64. You need to be `root` and/or have `sudo` privileges to install packages.
+
+# Step 1 - Preparation
+
+We will install Docker by using Ubuntu's APT package manager. To fetch the latest package database, use:
+
 ```bash
-    sudo apt-get update
+sudo apt-get update
 ```
 
-To add a custom package repository for docker we need a few apt-tools which might not be already present. Use the following command to install them:
+To add a custom package repository for Docker, we need a few apt tools that you may not have installed yet. Use the following command to install them:
 
 ```bash
 sudo apt-get install \
@@ -40,7 +44,7 @@ sudo apt-get install \
     lsb-release
 ```
 
-If there are multiple packages or dependencies to be installed, the installer might ask for your confirmation. Press ``y`` and ENTER when asked:
+If there are multiple packages or dependencies to be installed, the installer might ask for your confirmation. Press `y` and ENTER when asked:
 
 ```
 The following NEW packages will be installed:
@@ -51,20 +55,19 @@ After this operation, 51.6 MB of additional disk space will be used.
 Do you want to continue? [Y/n] y
 ```
 
+# Step 2 - Add custom repository and install Docker
 
-# Step 2 - (Add custom repository and install docker)
+## Step 2.1 - Add custom apt repository
 
+Docker gets shipped by a custom apt package repository hosted by the Docker organization. This provides newer and more frequently updated versions of docker-ce.
 
-## Step 2.1 - (Add custom apt repository)
-Docker gets shipped by a custom apt package repository hosted by docker organization. This provides newer and more frequently updated versions of docker-ce.
-
-At first you need to add dockers PGP Key. To do this execute the following command:
+At first you need to add Docker's PGP key. To do this, execute the following command:
 
 ```bash
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 ```
 
-After adding the key-file we need to add the new repository. To do this type:
+After adding the key file, we need to add the new repository. To do this, type:
 
 ```bash
 echo \
@@ -72,37 +75,41 @@ echo \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 ```
 
-To fetch all available packages from the newly added repository run
+To fetch all available packages from the newly added repository, run the following command again:
+
 ```bash
 sudo apt-get update
 ```
 
-again.
+## Step 2.2 - Install Docker
 
+To finally install the Docker package, run:
 
-
-## Step 2.2 - (Install Docker)
-To finally install the docker package run:
 ```bash
 sudo apt-get install docker-ce docker-ce-cli containerd.io
 ```
 
-## Step 2.3 - (Test if docker is working)
+## Step 2.3 - Test if Docker is working
 
-To test whether docker is working you can fetch the hello world image and start it by using:
+To test if Docker is working, you can fetch the "hello world" image and start it by using:
+
 ```
 sudo docker run --rm hello-world
 ```
 
-# Step 3 - (Setup UFW to have docker not bypass firewall rules) (Optional)
-If you're using ufw as an iptables frontend / firewall for your server - you should be cautious about dockers iptables modifications since docker bypasses rules defined with ufw. To fix this we have to modify a specififc UFW config file. This part is based on the [ufw-docker Github repository](https://github.com/chaifeng/ufw-docker) tutorial.
+# Step 3 - Set up ufw so Docker doesn't bypass firewall rules (optional)
 
-To check if your server is using UFW run 
+If you're using ufw as an iptables frontend/firewall for your server, you should be cautious with Docker's iptables modifications, as Docker will bypass the rules defined with ufw. To fix this, we have to modify a specific ufw config file. This part is based on the [ufw-docker Github repository](https://github.com/chaifeng/ufw-docker) tutorial.
+
+To check if your server is using ufw, run the following command:
+
 ```bash
 sudo ufw status
 ```
-and check whether the reported status is ``active``.
+
+Check if the reported status is `active`.
 The expected result should be similar to this:
+
 ```
 Status: active
 
@@ -111,23 +118,27 @@ To                         Action      From
 ...                         ...         ...
 ```
 
-If your server shows the inactive state, ufw is not enabled for your server. If you would like to enable it see **Step 3.1**
+If your server shows an "inactive" state, ufw is not enabled for your server. If you want to enable it, see **Step 3.1**
 
-## Step 3.1 - (Enable UFW) (Optional)
+## Step 3.1 - Enable ufw (optional)
 
-> **Important:** When enabling ufw and not adding a rule for ssh you might loose connectivity to your server. Make sure to add an appropriate rule for allowing ssh traffic on port ``22`` by using the following command:
+> **Important:** When enabling ufw and not adding a rule for SSH, you might lose connectivity to your server. Make sure to add an appropriate rule for allowing SSH traffic on port `22` by using the following command:
+>
 > ```bash
->   sudo ufw allow ssh
+> sudo ufw allow ssh
 > ```
-> You could also add this rule by using netcups web console feature found inside your server control panel.
+>
+> You can also add this rule by using netcup's web console feature found inside your server control panel.
 
-To enable ufw in case its not yet enabled you can run:
+To enable ufw in case it's not yet enabled, you can run:
+
 ```bash
 sudo ufw enable
 ```
 
-## Step 3.2 - (Setup UFW Config)
-Use an editor of your choice to edit the configuration file at ``/etc/ufw/after.rules`` (e.g. ``sudo nano /etc/ufw/after.rules``).
+## Step 3.2 - Set up ufw config
+
+Use an editor of your choice to edit the configuration file at `/etc/ufw/after.rules` (e.g. `sudo nano /etc/ufw/after.rules`).
 Add the following to the end of the file and save it:
 
 ```
@@ -160,34 +171,35 @@ COMMIT
 # END UFW AND DOCKER
 ```
 
-After saving the modifications restart the server to have the changes take effect.
+After saving the modifications, restart the server to have the changes take effect.
 
 ```bash
 sudo reboot
 ```
 
+## Step 3.3 - Using ufw to open ports
 
-## Step 3.3 - (Using ufw to open ports)
-When you want to publish a port from your containers use the following command:
+If you want to publish a port from your containers, use the following command:
 
-> This command publishes port 80 from any container's local port. Replace 80 with your custom ports for tcp communication. To use the UDP Protocol replace ``proto tcp`` with ``proto udp``.
+> This command publishes port 80 from any container's local port. Replace 80 with your custom ports for TCP communication. To use the UDP Protocol, replace `proto tcp` with `proto udp`.
 
 ```bash
 ufw route allow proto tcp from any to any port 80
 ```
 
-When you have multiple containers using the same port you can specify the container by its private (internal) ip:
+If you have multiple containers using the same port, you can specify the container by its private (internal) IP:
 
 ```bash
 ufw route allow proto tcp from any to 172.17.0.2 port 80
 ```
 
-> **Please Note:** the port used at the end of this commands is the **internal** port of the container! You dont need to expose them to the host.
+> **Please note:** The port used at the end of this command is the **internal** port of the container! You don't have to expose it to the host.
 
-## Step 3.4 - (Using the ufw-docker tool for easier setup)
-Instead of doing the above manual steps to install / configure ufw you could use an handy script provided by the authors of [ufw-docker Repository](https://github.com/chaifeng/ufw-docker).
+## Step 3.4 - Using the ufw-docker tool for easier setup
 
-To install the tool run the following command:
+Instead of performing the above manual steps to install/configure ufw, you can use a handy script provided by the authors of the [ufw-docker repository](https://github.com/chaifeng/ufw-docker).
+
+To install the tool, run the following command:
 
 ```bash
 sudo wget -O /usr/local/bin/ufw-docker \
@@ -195,28 +207,33 @@ sudo wget -O /usr/local/bin/ufw-docker \
 sudo chmod +x /usr/local/bin/ufw-docker
 ```
 
-To automatically apply the ufw ``after.rules`` change run:
+To automatically apply the ufw `after.rules` change, run:
+
 ```bash
 sudo ufw-docker install
 ```
 
-To publish a containers port use the command:
+To publish a container port, use the command:
+
 ```bash
 sudo ufw-docker allow <CONTAINER_NAME> <PORT>
 ```
 
-Further information and help can be shown by using:
+To display further information and help, use the command:
+
 ```bash
 sudo ufw-docker help
 ```
 
-# Step 4 - (Add your user to docker group to use Docker without sudo) (Optional)
-If you wish to use docker with your regular user without using ``sudo`` all the time you can add your user to the docker group.
-**Please bear in mind that users could exploit docker to gain root access to your host machine!**
+# Step 4 - Add your user to 'docker' group to use Docker without sudo (optional)
 
-To add your user to docker group run:
+If you wish to use Docker with your regular user without using `sudo` all the time, you can add your user to the "docker" group.
+**Please bear in mind that other users might exploit Docker to gain root access to your host machine!**
+
+To add your user to the "docker" group, run:
+
 ```bash
-# Create the docker group in case it not yet exist
+# Create the docker group in case it does not yet exist
 sudo groupadd docker
 # Add your user to the docker group
 sudo usermod -aG docker $USER
@@ -224,26 +241,29 @@ sudo usermod -aG docker $USER
 
 You need to log out and log back in to have the changes take effect.
 
-To test if this step was successfull you could run:
+To test if this step was successful, you can run the following command again without sudo:
+
 ```bash
 docker run --rm hello-world
 ```
-again without sudo.
 
+# Step 5 - Install docker-compose (optional)
 
-# Step 5 - (Install docker-compose) (Optional)
-When using apps / services that depend on multiple containers / images you could use ``docker-compose`` for easier setup / maintenance. This part is based on the [offical documentation for docker-compose](https://docs.docker.com/compose/install/).
-To install docker-compose run the following commands:
+When using apps/services that depend on multiple containers/images you can use `docker-compose` for easier setup/maintenance. This part is based on the [official documentation for docker-compose](https://docs.docker.com/compose/install/).
+To install docker-compose, run the following commands:
+
 ```bash
 sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 ```
 
-# Step 6 - (Install Portainer) (Optional)
-Portainer is a Software for managing docker containers with an handy web-ui.
-Additional Information can be found on the [offical documentation](https://docs.portainer.io/v/ce-2.9/start/install/server/docker/linux).
+# Step 6 - Install Portainer (optional)
 
-Portainer itself gets shipped as an docker image. To install simply create a new volume and run the container.
+Portainer is a software for managing Docker containers with a handy web UI.
+Additional information can be found in the [official documentation](https://docs.portainer.io/v/ce-2.9/start/install/server/docker/linux).
+
+Portainer itself gets shipped as a Docker image. To install it, simply create a new volume and run the container.
+
 ```bash
 docker volume create portainer_data
 docker run -d -p 9443:9443 --name portainer \
@@ -253,32 +273,35 @@ docker run -d -p 9443:9443 --name portainer \
     portainer/portainer-ce:latest
 ```
 
-When using the ufw modification you need to add port 9443 to make it reachable:
+If you use the ufw modification, you need to add port 9443 to make it reachable:
+
 ```bash
 sudo ufw-docker allow portainer 9443
 ```
 
-You can now reach portainer via your webbrowser by opening url: ``https://<YOURSERVER>:9443``. 
+You can now reach Portainer via your web browser by opening URL: `https://<YOURSERVER>:9443`.
 
-> **Note:** By default portainer is using a self-signed certificate. So there might be a warning appearing when you open the web panel for the first time.
+> **Note:** By default, Portainer is using a self-signed certificate. Therefore, a warning may appear when you open the web panel for the first time.
 
 # Conclusion
-The installation of docker is just the base for a lot of different applications and use-cases. You could for example install mailcow-dockerized or other software utilizing it.
-By using nginx as a reverse proxy inside docker or on your host machine you could have multiple webservices listen on the same port with different domain names / paths.
 
+Installing Docker is just the base for many different applications and use cases. For example, you can install "mailcow-dockerized" or other software that uses it.
+By using nginx as a reverse proxy inside Docker or on your host machine, you can have multiple webservices listen on the same port with different domain names/paths.
 
 # License
+
 MIT
 
 # Contributor's Certificate of Origin
-Contributor's Certificate of Origin By making a contribution to this project, I certify that:
 
- 1) The contribution was created in whole or in part by me and I have the right to submit it under the license indicated in the file; or
+By making a contribution to this project, I certify that:
 
- 2) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same license (unless I am permitted to submit under a different license), as indicated in the file; or
+1.  The contribution was created in whole or in part by me and I have the right to submit it under the license indicated in the file; or
 
- 3) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+2.  The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same license (unless I am permitted to submit under a different license), as indicated in the file; or
 
- 4) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the license(s) involved.
+3.  The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
 
-Signed-off-by: Marcel Aust <nc-wiki@marcel-aust.de>
+4.  I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the license(s) involved.
+
+Signed off by: Marcel Aust <nc-wiki@marcel-aust.de>

--- a/community-tutorials/ubuntu-docker-install/01-en.md
+++ b/community-tutorials/ubuntu-docker-install/01-en.md
@@ -1,0 +1,280 @@
+---
+title: Install Docker-CE on Ubuntu 20.04
+description: How to setup Docker-CE on Ubuntu 20.04
+updated_at: 2021-11-04
+slug: ubuntu-docker-install
+author_name: Marcel Aust
+author_url: https://marcel-aust.de
+author_image: -
+author_bio: -
+tags: [shell,docker,ubuntu,portainer,docker-compose] 
+netcup_product_url: https://www.netcup.de/bestellen/produkt.php?produkt=2000
+language: en
+available_languages: en
+---
+
+# Introduction
+This tutorial explains how to install Docker-CE on Ubuntu 20.04.
+With this tutorial you will learn how to install and configure Docker on Ubuntu to use it with many different apps and services.
+In addition this tutorial describes how to use Docker with **ufw** and additionally install and setup **docker-compose** and **portainer**.
+You should have a basic understanding of linux and shell commands. A fresh install of Ubuntu 20.04 (may work with other versions too) is required.
+
+This tutorial is based on the [offical tutorial provided by docker](https://docs.docker.com/engine/install/ubuntu/) with a few extra notes and additions.
+
+# Requirements
+Docker can be used on nearly any Root- or V-Server. Netcups server's architecture is amd64. You need to be root and/or have sudo privileges to install packages.
+
+# Step 1 - (Preparation)
+We will install Docker by using Ubuntus APT package manager. To fetch the latest package database, use:
+```bash
+    sudo apt-get update
+```
+
+To add a custom package repository for docker we need a few apt-tools which might not be already present. Use the following command to install them:
+
+```bash
+sudo apt-get install \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+```
+
+If there are multiple packages or dependencies to be installed, the installer might ask for your confirmation. Press ``y`` and ENTER when asked:
+
+```
+The following NEW packages will be installed:
+  ....
+0 upgraded, 64 newly installed, 0 to remove and 0 not upgraded.
+Need to get 13.5 MB of archives.
+After this operation, 51.6 MB of additional disk space will be used.
+Do you want to continue? [Y/n] y
+```
+
+
+# Step 2 - (Add custom repository and install docker)
+
+
+## Step 2.1 - (Add custom apt repository)
+Docker gets shipped by a custom apt package repository hosted by docker organization. This provides newer and more frequently updated versions of docker-ce.
+
+At first you need to add dockers PGP Key. To do this execute the following command:
+
+```bash
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+```
+
+After adding the key-file we need to add the new repository. To do this type:
+
+```bash
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+```
+
+To fetch all available packages from the newly added repository run
+```bash
+sudo apt-get update
+```
+
+again.
+
+
+
+## Step 2.2 - (Install Docker)
+To finally install the docker package run:
+```bash
+sudo apt-get install docker-ce docker-ce-cli containerd.io
+```
+
+## Step 2.3 - (Test if docker is working)
+
+To test whether docker is working you can fetch the hello world image and start it by using:
+```
+sudo docker run --rm hello-world
+```
+
+# Step 3 - (Setup UFW to have docker not bypass firewall rules) (Optional)
+If you're using ufw as an iptables frontend / firewall for your server - you should be cautious about dockers iptables modifications since docker bypasses rules defined with ufw. To fix this we have to modify a specififc UFW config file. This part is based on the [ufw-docker Github repository](https://github.com/chaifeng/ufw-docker) tutorial.
+
+To check if your server is using UFW run 
+```bash
+sudo ufw status
+```
+and check whether the reported status is ``active``.
+The expected result should be similar to this:
+```
+Status: active
+
+To                         Action      From
+--                         ------      ----
+...                         ...         ...
+```
+
+If your server shows the inactive state, ufw is not enabled for your server. If you would like to enable it see **Step 3.1**
+
+## Step 3.1 - (Enable UFW) (Optional)
+
+To enable ufw in case its not yet enabled you can run:
+```bash
+sudo ufw enable
+```
+
+> **Important:** When enabling ufw and not adding a rule for ssh you might loose connectivity to your server. Make sure to add an appropriate rule for allowing ssh traffic on port ``22`` by using the following command:
+> ```bash
+>   sudo ufw allow ssh
+> ```
+> You could also add this rule by using netcups web console feature found inside your server control panel.
+
+
+## Step 3.2 - (Setup UFW Config)
+Use an editor of your choice to edit the configuration file at ``/etc/ufw/after.rules`` (e.g. ``sudo nano /etc/ufw/after.rules``).
+Add the following to the end of the file and save it:
+
+```
+# BEGIN UFW AND DOCKER
+*filter
+:ufw-user-forward - [0:0]
+:ufw-docker-logging-deny - [0:0]
+:DOCKER-USER - [0:0]
+-A DOCKER-USER -j ufw-user-forward
+
+-A DOCKER-USER -j RETURN -s 10.0.0.0/8
+-A DOCKER-USER -j RETURN -s 172.16.0.0/12
+-A DOCKER-USER -j RETURN -s 192.168.0.0/16
+
+-A DOCKER-USER -p udp -m udp --sport 53 --dport 1024:65535 -j RETURN
+
+-A DOCKER-USER -j ufw-docker-logging-deny -p tcp -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -d 192.168.0.0/16
+-A DOCKER-USER -j ufw-docker-logging-deny -p tcp -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -d 10.0.0.0/8
+-A DOCKER-USER -j ufw-docker-logging-deny -p tcp -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -d 172.16.0.0/12
+-A DOCKER-USER -j ufw-docker-logging-deny -p udp -m udp --dport 0:32767 -d 192.168.0.0/16
+-A DOCKER-USER -j ufw-docker-logging-deny -p udp -m udp --dport 0:32767 -d 10.0.0.0/8
+-A DOCKER-USER -j ufw-docker-logging-deny -p udp -m udp --dport 0:32767 -d 172.16.0.0/12
+
+-A DOCKER-USER -j RETURN
+
+-A ufw-docker-logging-deny -m limit --limit 3/min --limit-burst 10 -j LOG --log-prefix "[UFW DOCKER BLOCK] "
+-A ufw-docker-logging-deny -j DROP
+
+COMMIT
+# END UFW AND DOCKER
+```
+
+After saving the modifications restart the server to have the changes take effect.
+
+```bash
+sudo reboot
+```
+
+
+## Step 3.3 - (Using ufw to open ports)
+When you want to publish a port from your containers use the following command:
+
+> This command publishes port 80 from any container's local port. Replace 80 with your custom ports for tcp communication. To use the UDP Protocol replace ``proto tcp`` with ``proto udp``.
+
+```bash
+ufw route allow proto tcp from any to any port 80
+```
+
+When you have multiple containers using the same port you can specify the container by its private (internal) ip:
+
+```bash
+ufw route allow proto tcp from any to 172.17.0.2 port 80
+```
+
+> **Please Note:** the port used at the end of this commands is the **internal** port of the container! You dont need to expose them to the host.
+
+## Step 3.4 - (Using the ufw-docker tool for easier setup)
+Instead of doing the above manual steps to install / configure ufw you could use an handy script provided by the authors of [ufw-docker Repository](https://github.com/chaifeng/ufw-docker).
+
+To install the tool run the following command:
+
+```bash
+sudo wget -O /usr/local/bin/ufw-docker \
+  https://github.com/chaifeng/ufw-docker/raw/master/ufw-docker
+sudo chmod +x /usr/local/bin/ufw-docker
+```
+
+To automatically apply the ufw ``after.rules`` change run:
+```bash
+sudo ufw-docker install
+```
+
+To publish a containers port use the command:
+```bash
+sudo ufw-docker allow CONTAINER_NAME PORT
+```
+
+Further information and help can be shown by using:
+```bash
+sudo ufw-docker help
+```
+
+# Step 4 - (Add your user to docker group to use Docker without sudo) (Optional)
+If you wish to use docker with your regular user without using ``sudo`` all the time you can add your user to the docker group.
+**Please bear in mind that users could exploit docker to gain root access to your host machine!**
+
+To add your user to docker group run:
+```bash
+# Create the docker group in case it not yet exist
+sudo groupadd docker
+# Add your user to the docker group
+sudo usermod -aG docker $USER
+```
+
+You need to log out and log back in to have the changes take effect.
+
+
+# Step 5 - (Install docker-compose) (Optional)
+When using apps / services that depend on multiple containers / images you could use ``docker-compose`` for easier setup / maintenance. This part is based on the [offical documentation for docker-compose](https://docs.docker.com/compose/install/).
+To install docker-compose run the following commands:
+```bash
+sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+```
+
+# Step 6 - (Install Portainer) (Optional)
+Portainer is a Software for managing docker containers with an handy web-ui.
+Additional Information can be found on the [offical documentation](https://docs.portainer.io/v/ce-2.9/start/install/server/docker/linux).
+
+Portainer itself gets shipped as an docker image. To install simply create a new volume and run the container.
+```bash
+docker volume create portainer_data
+docker run -d -p 9443:9443 --name portainer \
+    --restart=always \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v portainer_data:/data \
+    portainer/portainer-ce:latest
+```
+
+When using the ufw modification you need to add port 9443 to make it reachable:
+```bash
+sudo ufw-docker allow portainer 9443
+```
+
+You can now reach portainer via your webbrowser by opening url: ``https://YOURSERVER:9443``. 
+
+> **Note:** By default portainer is using a self-signed certificate. So there might be a warning appearing when you open the web panel for the first time.
+
+# Conclusion
+The installation of docker is just the base for a lot of different applications and use-cases. You could for example install mailcow-dockerized or other software utilizing it.
+By using nginx as a reverse proxy inside docker or on your host machine you could have multiple webservices listen on the same port with different domain names / paths.
+
+**TBA: Links to other wiki articles**
+
+# License
+MIT
+
+# Contributor's Certificate of Origin
+Contributor's Certificate of Origin By making a contribution to this project, I certify that:
+
+ 1) The contribution was created in whole or in part by me and I have the right to submit it under the license indicated in the file; or
+
+ 2) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same license (unless I am permitted to submit under a different license), as indicated in the file; or
+
+ 3) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+
+ 4) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the license(s) involved.
+
+Signed-off-by: Marcel Aust <nc-wiki@marcel-aust.de>

--- a/community-tutorials/ubuntu-docker-install/01-en.md
+++ b/community-tutorials/ubuntu-docker-install/01-en.md
@@ -1,13 +1,13 @@
 ---
-title: Install Docker-CE on Ubuntu 20.04
-description: How to setup Docker-CE on Ubuntu 20.04
+title: Install Docker-CE on Ubuntu 20.04 with docker-compose, portainer and ufw
+description: How to setup Docker-CE on Ubuntu 20.04 with docker-compose and portainer for better management. Additional ufw configuration instructions for additional security
 updated_at: 2021-11-04
-slug: ubuntu-docker-install
+slug: ubuntu-docker-install-with-compose-and-portainer
 author_name: Marcel Aust
 author_url: https://marcel-aust.de
 author_image: -
 author_bio: -
-tags: [shell,docker,ubuntu,portainer,docker-compose] 
+tags: [shell,docker,ubuntu,portainer,docker-compose,ufw] 
 netcup_product_url: https://www.netcup.de/bestellen/produkt.php?produkt=2000
 language: en
 available_languages: en
@@ -224,6 +224,12 @@ sudo usermod -aG docker $USER
 
 You need to log out and log back in to have the changes take effect.
 
+To test if this step was successfull you could run:
+```bash
+docker run --rm hello-world
+```
+again without sudo.
+
 
 # Step 5 - (Install docker-compose) (Optional)
 When using apps / services that depend on multiple containers / images you could use ``docker-compose`` for easier setup / maintenance. This part is based on the [offical documentation for docker-compose](https://docs.docker.com/compose/install/).
@@ -252,7 +258,7 @@ When using the ufw modification you need to add port 9443 to make it reachable:
 sudo ufw-docker allow portainer 9443
 ```
 
-You can now reach portainer via your webbrowser by opening url: ``https://YOURSERVER:9443``. 
+You can now reach portainer via your webbrowser by opening url: ``https://<YOURSERVER>:9443``. 
 
 > **Note:** By default portainer is using a self-signed certificate. So there might be a warning appearing when you open the web panel for the first time.
 
@@ -260,7 +266,6 @@ You can now reach portainer via your webbrowser by opening url: ``https://YOURSE
 The installation of docker is just the base for a lot of different applications and use-cases. You could for example install mailcow-dockerized or other software utilizing it.
 By using nginx as a reverse proxy inside docker or on your host machine you could have multiple webservices listen on the same port with different domain names / paths.
 
-**TBA: Links to other wiki articles**
 
 # License
 MIT

--- a/community-tutorials/ubuntu-docker-install/01-en.md
+++ b/community-tutorials/ubuntu-docker-install/01-en.md
@@ -115,17 +115,16 @@ If your server shows the inactive state, ufw is not enabled for your server. If 
 
 ## Step 3.1 - (Enable UFW) (Optional)
 
-To enable ufw in case its not yet enabled you can run:
-```bash
-sudo ufw enable
-```
-
 > **Important:** When enabling ufw and not adding a rule for ssh you might loose connectivity to your server. Make sure to add an appropriate rule for allowing ssh traffic on port ``22`` by using the following command:
 > ```bash
 >   sudo ufw allow ssh
 > ```
 > You could also add this rule by using netcups web console feature found inside your server control panel.
 
+To enable ufw in case its not yet enabled you can run:
+```bash
+sudo ufw enable
+```
 
 ## Step 3.2 - (Setup UFW Config)
 Use an editor of your choice to edit the configuration file at ``/etc/ufw/after.rules`` (e.g. ``sudo nano /etc/ufw/after.rules``).


### PR DESCRIPTION
This adds a tutorial for installing docker on ubuntu linux. It's based on the official documentation but includes a few extra steps and tools. I plan to make a few more tutorials including installation of mailcow-docerized or nginx as an reverse proxy for a few docker based services using the same port with automatic ssl certificate renewal by using certbot or installation and configuration of pterodactyl for game server hosting etc. But I would like to get feedback about depth and quality of this tutorial first before I make more.. Thanks! 
Disclaimer: My English might include some spelling and grammar mistakes. Please notify me about them when you come across them. 

I have read and understood the Contributor's Certificate of Origin at the end of the template and I hereby certify that I meet the contribution criteria described in it.

Signed-off-by: Marcel Aust <nc-wiki@marcel-aust.de>