### PR TITLE
Add tutorial for setting up nginx reverse proxy with docker

### DIFF
--- a/community-tutorials/install-reverse-proxy/01-en.md
+++ b/community-tutorials/install-reverse-proxy/01-en.md
@@ -1,0 +1,161 @@
+---
+title: Setup a Nginx reverse proxy with LetsEcnrypt
+description: How to set up a reverse proxy to forward HTTP traffic on different subdomains to different containers
+updated_at: 2021-11-04
+slug: how-to-setup-nginx-reverse-proxy
+author_name: Leonard Seibold
+author_url: https://github.com/zortax
+author_image: https://avatars.githubusercontent.com/u/13034313?v=4
+author_bio: 
+tags: docker, docker, docker-compose, nginx, letsencrypt, reverse-proxy
+netcup_product_url: https://www.netcup.de/bestellen/produkt.php?produkt=2000
+language: en
+available_languages: en
+---
+
+# Introduction
+In this tutorial, we will set up a Nginx reverse proxy using Docker and
+docker-compose. This will allow us to route HTTP requests arriving via different
+subdomains to web services running in different docker containers. We will also
+setup a LetsEncrypt CertBot to automatically create and renew TLS certificates.
+
+
+# Requirements
+- A server (root or VPS)
+- A working Docker installation
+- A working docker-compose installation
+
+## Step 1 - Define the services using docker compose
+
+Create a new YAML file `reverse-proxy.yml` and open it using an editor of your
+choice:
+```
+vim docker-compose.yml
+```
+
+Insert the following:
+```yml
+version: '3'
+
+services:
+    nginx:
+        image: jwilder/nginx-proxy
+        container_name: nginx-proxy
+        restart: always
+        logging:
+            driver: "json-file"
+            options:
+                max-size: "50m"
+                max-file: "1"
+        ports:
+            - '80:80'
+            - '443:443'
+        volumes:
+            - conf:/etc/nginx/conf.d
+            - certs:/etc/nginx/certs
+            - vhost:/etc/nginx/vohost.d
+            - html:/usr/share/nginx/html
+            - dhparam:/etc/nginx/dhparam
+            - '/var/run/docker.sock:/tmp/docker.sock:ro'
+            - '/srv/data/nginx/proxy.conf:/etc/nginx/proxy.conf'
+
+    nginx-proxy-le:
+        image: jrcs/letsencrypt-nginx-proxy-companion
+        container_name: nginx-proxy-le
+        restart: always
+        logging:
+            driver: "json-file"
+            options:
+                max-size: "50m"
+                max-file: "1"
+        volumes:
+            - conf:/etc/nginx/conf.d
+            - certs:/etc/nginx/certs:rw
+            - vhost:/etc/nginx/vhost.d
+            - html:/usr/share/nginx/html
+            - '/var/run/docker.sock:/var/run/docker.sock:ro'
+        environment:
+            NGINX_PROXY_CONTAINER: nginx-proxy
+
+networks:
+    default:
+        external:
+            name: compose-net
+
+volumes:
+    conf:
+    vhost:
+    html:
+    certs:
+    dhparam:
+```
+
+This docker-compose file will create two services: the `nginx-proxy` container
+will run the Nginx reverse proxy, `nginx-proxy-le` will manage LetsEcnrypt's TLS
+certificates. Notice that the log files have a size limit to avoid disk space
+running out. You can of course change this. The Nginx config can be found in the
+`conf` docker volume (though it should not be necessary to edit it manually).
+
+## Step 2 - Deploying the services
+Use docker-compose to deploy both containers and auto-create the Docker network
+and volumes:
+```
+docker-compose -f revers-proxy.yml up -d
+```
+If you are not currently the root user and did not set up your user to be able
+to use docker, you may have to run this command with `sudo` privileges.
+
+
+## Step 3 - Setup you web services
+You can now set up your web services to be reachable under a given subdomain.
+Just set the subdomain you want to route to a service using the `VIRTUAL_HOST`
+environment variable. If you are using a different docker-compose file for your
+services, make sure to use the same docker network as with the reverse proxy:
+
+```yml
+# my-service.yml
+version: "3"
+services:
+    whoami:
+        image: jwilder/whoami
+        environment:
+          - VIRTUAL_HOST=whoami.your-domain.de
+
+networks:
+    default:
+        external:
+            name: compose-net
+```
+
+Make sure your sub domain resolves to your server's public IP address, then
+deploy your web service:
+```
+docker-compose -f my-service.yml up -d
+```
+
+The LetsEncrypt companion container should now automatically request a TLS
+certificate and set up the reverse proxy to route requests to your service
+afterwards. Give it a few minutes (as key generation might take a while), than
+try reaching your service at `whoami.your-domain.de` (or whatever subdomain you
+used) from your web browser.
+
+# Conclusion
+This fully automated setup makes it easy to deploy multiple web services without
+having to use multiple IP addresses. It also handles TLS certificates for you,
+making it easy to make services available publicly.
+
+# License
+MIT
+
+# Contributor's Certificate of Origin
+Contributor's Certificate of Origin By making a contribution to this project, I certify that:
+
+ 1) The contribution was created in whole or in part by me and I have the right to submit it under the license indicated in the file; or
+
+ 2) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same license (unless I am permitted to submit under a different license), as indicated in the file; or
+
+ 3) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+
+ 4) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the license(s) involved.
+
+Signed-off-by: Leonard Seibold <leo@zrtx.de>

--- a/community-tutorials/install-reverse-proxy/01-en.md
+++ b/community-tutorials/install-reverse-proxy/01-en.md
@@ -57,7 +57,6 @@ services:
             - html:/usr/share/nginx/html
             - dhparam:/etc/nginx/dhparam
             - '/var/run/docker.sock:/tmp/docker.sock:ro'
-            - '/srv/data/nginx/proxy.conf:/etc/nginx/proxy.conf'
 
     nginx-proxy-le:
         image: jrcs/letsencrypt-nginx-proxy-companion

--- a/community-tutorials/install-reverse-proxy/01-en.md
+++ b/community-tutorials/install-reverse-proxy/01-en.md
@@ -90,7 +90,7 @@ volumes:
 ```
 
 This docker-compose file will create two services: the `nginx-proxy` container
-will run the Nginx reverse proxy, `nginx-proxy-le` will manage LetsEcnrypt's TLS
+will run the Nginx reverse proxy, `nginx-proxy-le` will manage LetsEncrypt's TLS
 certificates. Notice that the log files have a size limit to avoid disk space
 running out. You can of course change this. The Nginx config can be found in the
 `conf` docker volume (though it should not be necessary to edit it manually).
@@ -99,7 +99,7 @@ running out. You can of course change this. The Nginx config can be found in the
 Use docker-compose to deploy both containers and auto-create the Docker network
 and volumes:
 ```
-docker-compose -f revers-proxy.yml up -d
+docker-compose -f reverse-proxy.yml up -d
 ```
 If you are not currently the root user and did not set up your user to be able
 to use docker, you may have to run this command with `sudo` privileges.

--- a/community-tutorials/install-reverse-proxy/01-en.md
+++ b/community-tutorials/install-reverse-proxy/01-en.md
@@ -110,7 +110,7 @@ and volumes:
 ```
 docker-compose -f reverse-proxy.yml up -d
 ```
-Just as in Step 2 you might need `sudo` privileges depending on you system
+Just as in Step 2 you might need `sudo` privileges, depending on your system
 setup.
 
 
@@ -122,7 +122,7 @@ services, make sure to use the same docker network as with the reverse proxy:
 
 ```yml
 # my-service.yml
-version: "3"
+version: '3'
 services:
     whoami:
         image: jwilder/whoami

--- a/community-tutorials/install-reverse-proxy/01-en.md
+++ b/community-tutorials/install-reverse-proxy/01-en.md
@@ -6,7 +6,7 @@ slug: how-to-setup-nginx-reverse-proxy
 author_name: Leonard Seibold
 author_url: https://github.com/zortax
 author_image: https://avatars.githubusercontent.com/u/13034313?v=4
-author_bio: 
+author_bio: -
 tags: [docker, docker, docker-compose, nginx, letsencrypt, reverse-proxy]
 netcup_product_url: https://www.netcup.de/bestellen/produkt.php?produkt=2000
 language: en

--- a/community-tutorials/install-reverse-proxy/01-en.md
+++ b/community-tutorials/install-reverse-proxy/01-en.md
@@ -7,7 +7,7 @@ author_name: Leonard Seibold
 author_url: https://github.com/zortax
 author_image: https://avatars.githubusercontent.com/u/13034313?v=4
 author_bio: 
-tags: docker, docker, docker-compose, nginx, letsencrypt, reverse-proxy
+tags: [docker, docker, docker-compose, nginx, letsencrypt, reverse-proxy]
 netcup_product_url: https://www.netcup.de/bestellen/produkt.php?produkt=2000
 language: en
 available_languages: en

--- a/community-tutorials/install-reverse-proxy/01-en.md
+++ b/community-tutorials/install-reverse-proxy/01-en.md
@@ -30,7 +30,7 @@ setup a LetsEncrypt CertBot to automatically create and renew TLS certificates.
 Create a new YAML file `reverse-proxy.yml` and open it using an editor of your
 choice:
 ```
-vim docker-compose.yml
+vim reverse-proxy.yml
 ```
 
 Insert the following:

--- a/community-tutorials/install-reverse-proxy/01-en.md
+++ b/community-tutorials/install-reverse-proxy/01-en.md
@@ -104,7 +104,7 @@ docker network create compose-net
 If you are not currently the root user and did not set up your user to be able
 to use docker, you may have to run this command with `sudo` privileges.
 
-## Step 3 - Deploying the services
+## Step 3 - Deploy the services
 Use docker-compose to deploy both containers and auto-create the Docker network
 and volumes:
 ```
@@ -114,7 +114,7 @@ Just as in Step 2 you might need `sudo` privileges depending on you system
 setup.
 
 
-## Step 4 - Setup you web services
+## Step 4 - Setup your web services
 You can now set up your web services to be reachable under a given subdomain.
 Just set the subdomain you want to route to a service using the `VIRTUAL_HOST`
 environment variable. If you are using a different docker-compose file for your

--- a/community-tutorials/install-reverse-proxy/01-en.md
+++ b/community-tutorials/install-reverse-proxy/01-en.md
@@ -1,6 +1,6 @@
 ---
-title: Setup a Nginx reverse proxy with LetsEcnrypt
-description: How to set up a reverse proxy to forward HTTP traffic on different subdomains to different containers
+title: Setting up an nginx Reverse Proxy with Docker
+description: Learn how to set up a reverse proxy to forward HTTP traffic on different subdomains to different containers. Also includes setup descriptions for a LetsEncrypt CertBot.
 updated_at: 2021-11-04
 slug: how-to-setup-nginx-reverse-proxy
 author_name: Leonard Seibold
@@ -14,26 +14,29 @@ available_languages: en
 ---
 
 # Introduction
-In this tutorial, we will set up a Nginx reverse proxy using Docker and
-docker-compose. This will allow us to route HTTP requests arriving via different
-subdomains to web services running in different docker containers. We will also
-setup a LetsEncrypt CertBot to automatically create and renew TLS certificates.
 
+In this tutorial, we will set up an nginx reverse proxy using Docker and
+docker-compose. This will allow us to route HTTP requests arriving through different
+subdomains to web services running in different Docker containers. We will also
+set up a LetsEncrypt CertBot to automatically create and renew TLS certificates.
 
 # Requirements
-- A server (root or VPS)
-- A working Docker installation
-- A working docker-compose installation
 
-## Step 1 - Define the services using docker compose
+- Server (root or VPS)
+- Working Docker installation
+- Working docker-compose installation.
+
+## Step 1 - Define the services using docker-compose
 
 Create a new YAML file `reverse-proxy.yml` and open it using an editor of your
 choice:
+
 ```
 vim reverse-proxy.yml
 ```
 
 Insert the following:
+
 ```yml
 version: '3'
 
@@ -89,36 +92,41 @@ volumes:
     dhparam:
 ```
 
-This docker-compose file will create two services: the `nginx-proxy` container
-will run the Nginx reverse proxy, `nginx-proxy-le` will manage LetsEncrypt's TLS
-certificates. Notice that the log files have a size limit to avoid disk space
-running out. You can of course change this. The Nginx config can be found in the
-`conf` docker volume (though it should not be necessary to edit it manually).
+This docker-compose file will create two services: The `nginx-proxy` container
+will run the nginx reverse proxy, while `nginx-proxy-le` will manage LetsEncrypt's TLS
+certificates. Please note that the log files have a size limit to avoid running out of disk space.
+You can of course change this. The nginx config can be found in the
+`conf` Docker volume (though it should not be necessary to edit it manually).
 
-## Step 2 - Create the docker network
-Run the following command using the following Docker command:
+## Step 2 - Create the Docker network
+
+Run the following Docker command:
+
 ```
 docker network create compose-net
 ```
 
-If you are not currently the root user and did not set up your user to be able
-to use docker, you may have to run this command with `sudo` privileges.
+If you are currently not the `root` user and did not set up your user to
+use Docker, you may have to run this command with `sudo` privileges.
 
 ## Step 3 - Deploy the services
+
 Use docker-compose to deploy both containers and auto-create the Docker network
 and volumes:
+
 ```
 docker-compose -f reverse-proxy.yml up -d
 ```
-Just as in Step 2 you might need `sudo` privileges, depending on your system
+
+Just as in Step 2, you might need `sudo` privileges depending on your system
 setup.
 
+## Step 4 - Set up your web services
 
-## Step 4 - Setup your web services
 You can now set up your web services to be reachable under a given subdomain.
-Just set the subdomain you want to route to a service using the `VIRTUAL_HOST`
-environment variable. If you are using a different docker-compose file for your
-services, make sure to use the same docker network as with the reverse proxy:
+Just define the subdomain you want to route to a service using the `VIRTUAL_HOST`
+environment variable. If you use a different docker-compose file for your
+services, make sure to use the same Docker network as for the reverse proxy:
 
 ```yml
 # my-service.yml
@@ -135,35 +143,39 @@ networks:
             name: compose-net
 ```
 
-Make sure your sub domain resolves to your server's public IP address, then
+Make sure that your subdomain resolves to your server's public IP address, then
 deploy your web service:
+
 ```
 docker-compose -f my-service.yml up -d
 ```
 
 The LetsEncrypt companion container should now automatically request a TLS
-certificate and set up the reverse proxy to route requests to your service
-afterwards. Give it a few minutes (as key generation might take a while), than
+certificate and set up the reverse proxy in order to route requests to your service
+afterwards. Give it a few minutes (as key generation might take a while), then
 try reaching your service at `whoami.your-domain.de` (or whatever subdomain you
 used) from your web browser.
 
 # Conclusion
+
 This fully automated setup makes it easy to deploy multiple web services without
 having to use multiple IP addresses. It also handles TLS certificates for you,
-making it easy to make services available publicly.
+making it easy to make services publicly available.
 
 # License
+
 MIT
 
 # Contributor's Certificate of Origin
-Contributor's Certificate of Origin By making a contribution to this project, I certify that:
 
- 1) The contribution was created in whole or in part by me and I have the right to submit it under the license indicated in the file; or
+By making a contribution to this project, I certify that:
 
- 2) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same license (unless I am permitted to submit under a different license), as indicated in the file; or
+1.  The contribution was created in whole or in part by me and I have the right to submit it under the license indicated in the file; or
 
- 3) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+2.  The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same license (unless I am permitted to submit under a different license), as indicated in the file; or
 
- 4) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the license(s) involved.
+3.  The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
 
-Signed-off-by: Leonard Seibold <leo@zrtx.de>
+4.  I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the license(s) involved.
+
+Signed off by: Leonard Seibold <leo@zrtx.de>

--- a/community-tutorials/install-reverse-proxy/01-en.md
+++ b/community-tutorials/install-reverse-proxy/01-en.md
@@ -95,17 +95,26 @@ certificates. Notice that the log files have a size limit to avoid disk space
 running out. You can of course change this. The Nginx config can be found in the
 `conf` docker volume (though it should not be necessary to edit it manually).
 
-## Step 2 - Deploying the services
+## Step 2 - Create the docker network
+Run the following command using the following Docker command:
+```
+docker network create compose-net
+```
+
+If you are not currently the root user and did not set up your user to be able
+to use docker, you may have to run this command with `sudo` privileges.
+
+## Step 3 - Deploying the services
 Use docker-compose to deploy both containers and auto-create the Docker network
 and volumes:
 ```
 docker-compose -f reverse-proxy.yml up -d
 ```
-If you are not currently the root user and did not set up your user to be able
-to use docker, you may have to run this command with `sudo` privileges.
+Just as in Step 2 you might need `sudo` privileges depending on you system
+setup.
 
 
-## Step 3 - Setup you web services
+## Step 4 - Setup you web services
 You can now set up your web services to be reachable under a given subdomain.
 Just set the subdomain you want to route to a service using the `VIRTUAL_HOST`
 environment variable. If you are using a different docker-compose file for your


### PR DESCRIPTION
This PR adds a tutorial on how to setup a nginx reverse proxy with automatic LetsEncrypt support using docker and docker-compose

I have read and understood the Contributor's Certificate of Origin at the end of the template and I hereby certify that I meet the contribution criteria described in it.

Signed-off-by: Leonard Seibold <leo@zrtx.de>