### PR TITLE
Add tutorial for HA with keepalived, Failover IPv4 and Cloud vLAN

### DIFF
--- a/community-tutorials/high-availability-keepalived/01-en.md
+++ b/community-tutorials/high-availability-keepalived/01-en.md
@@ -1,6 +1,6 @@
 ---
-title: High-Availability with keepalived and Failover IP
-description: This tutorial describes the setup process of a high-availability cluster with keepalived and a Failover IP
+title: Setting up a High Availability Cluster with Keepalived and Failover IPv4
+description: Learn how to set up a high availability cluster with Keepalived and a Failover IPv4.
 updated_at: 2021-11-09
 slug: high-availability-keepalived-failover
 author_name: Marcel Pabst
@@ -14,65 +14,86 @@ available_languages: en
 ---
 
 # Introduction
-High-availability (HA) refers to the ability of a system to continue operating with a high probability despite the failure of one of its components. There are several applications that help us to achieve high-availability. In this tutorial we will use [keepalived](https://github.com/acassen/keepalived) an application for loadbalancing and high-availability, which uses the Virtual Router Redundancy Protocol (VRRP; [RFC5798](https://datatracker.ietf.org/doc/html/rfc5798)). 
 
-Keepalived is used as a daemon that monitors the system state or certain conditions to automatically failover to a standby system if an error occurs. We will additionally use a [Netcup Failover-IPv4](https://www.netcup.de/bestellen/produkt.php?produkt=1073) and a [Cloud vLAN Free](https://www.netcup.de/bestellen/produkt.php?produkt=2284).
+High availability (HA) refers to the ability of a system to continue operating with a high probability despite the failure of one of its components. There are several applications that help us to achieve high availability. In this tutorial we will use [Keepalived](https://github.com/acassen/keepalived), an application for load balancing and high availability, which uses the Virtual Router Redundancy Protocol (VRRP; [RFC5798](https://datatracker.ietf.org/doc/html/rfc5798)).
 
-Please note that this is not an absolute beginners tutorial. I use references to other tutorials or the official documentation of used applications. If there are already instructions, I see no reason to write them again. So the main point here is how to implement a high availability setup with the mentioned products in the Netcup environment.
+Keepalived is used as a daemon that monitors the system state or certain conditions to automatically fail over to a standby system if an error occurs. We will additionally use a [netcup Failover IPv4](https://www.netcup.de/bestellen/produkt.php?produkt=1073) and a [Cloud vLAN Free](https://www.netcup.de/bestellen/produkt.php?produkt=2284).
 
-This tutorial may also be used as a starting point for other distributions but some modifications will be neccessary. 
+Please note that this is not a tutorial for absolute beginners. I use references to other tutorials or the official documentation of the applications used. If instructions already exist, I see no reason to write them again. So the main point here is how to implement a high availability setup with the mentioned products in the netcup environment.
+
+This tutorial can also be used as a starting point for other distributions, but some modifications will be required.
 
 # Requirements
-- Two Servers either [vServers](https://www.netcup.de/vserver/vps.php) or [Root Servers](https://www.netcup.de/vserver/) with Debian
+
+- 2 servers: Either [vServers](https://www.netcup.de/vserver/vps.php) or [root servers](https://www.netcup.de/vserver/) with Debian installed
 - [Failover IPv4](https://www.netcup.de/bestellen/produkt.php?produkt=1073)
 - [Cloud vLAN Free](https://www.netcup.de/bestellen/produkt.php?produkt=2284) (or higher)
 - Access to your [Customer Control Panel (CCP)](https://www.customercontrolpanel.de) & [Server Control Panel (SCP)](https://www.servercontrolpanel.de)
-- Access to a user with root privileges 
+- Access to a user with root privileges.
 
-I assume that you have already booked the mentioned products and fulfill the stated requirements. I will simply refer to the two servers as server 1 (s1) and server 2 (s2). If I am not stating a specific server it means that the commands need to be executed on both servers.
+I assume that you have already ordered the mentioned products and fulfill the stated requirements. I will simply refer to the two servers as server 1 (s1) and server 2 (s2). If I do not specify a particular server, it means that the commands must be executed on both servers.
 
-# Step 1 - Setup Cloud vLAN
-## Step 1.1 - Preparation SCP
-### Step 1.1.1 - Log in to your [SCP](https://www.servercontrolpanel.de), either directly or via the autologin feature in your [CCP](https://www.customercontrolpanel.de)
-### Step 1.1.2 - Choose a server (from the list on the top left) 
-### Step 1.1.3 - Navigate to the *Network* section (in the left sidebar)
-### Step 1.1.4 - Choose *add Ethernet Interface* (on the top right)
-### Step 1.1.5 - Select your Cloud vLAN and choose *virtio* as the driver
-### Step 1.1.6 - Select the second server and repeat the steps 1.1.3 - 1.1.5; then continue with 1.2
+# Step 1 - Set up Cloud vLAN
+
+## Step 1.1 - Preparation
+
+### Step 1.1.1 - Log in to your [SCP](https://www.servercontrolpanel.de), either directly or via the autologin feature in your [CCP](https://www.customercontrolpanel.de).
+
+### Step 1.1.2 - Choose a server (from the list on the top left side).
+
+### Step 1.1.3 - Navigate to the _Network_ section (in the left sidebar).
+
+### Step 1.1.4 - Choose _add Ethernet Interface_ (on the top right side).
+
+### Step 1.1.5 - Select your Cloud vLAN and choose _virtio_ as the driver.
+
+### Step 1.1.6 - Select the second server and repeat steps 1.1.3 - 1.1.5; then continue with 1.2.
+
 ## Step 1.2 - Create interface
-Log in to your servers and create a vLAN-configuration for the network interface via your favourite text editor e.g. `sudo vim /etc/network/interfaces.d/vlan.cfg`
 
-**Example */etc/network/interfaces.d/vlan.cfg* for s1**
+Log in to your servers and create a vLAN configuration for the network interface using your favorite text editor, e.g. `sudo vim /etc/network/interfaces.d/vlan.cfg`:
+
+**Example _/etc/network/interfaces.d/vlan.cfg_ for s1**
+
 ```
 auto eth1
 iface eth1 inet static
     address 10.132.0.10
     netmask 255.255.255.0
 ```
-**Example */etc/network/interfaces.d/vlan.cfg* for s2**
+
+**Example _/etc/network/interfaces.d/vlan.cfg_ for s2**
+
 ```
 auto eth1
 iface eth1 inet static
     address 10.132.0.20
     netmask 255.255.255.0
 ```
-## Step 1.3 - Restart networking 
+
+## Step 1.3 - Restart networking
+
 ```
 sudo systemctl restart networking
 ```
-## Step 1.4 - Verify vLAN Setup
-There are various methods to verify if your vLAN is setup correctly. You could for example start with a simple check via `ip addr show`:
+
+## Step 1.4 - Verify vLAN setup
+
+There are various methods to verify that your vLAN is set up correctly. For example, you could start with a simple check using `ip addr show`:
+
 ```
 3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
     link/ether e6:1c:ef:12:66:ae brd ff:ff:ff:ff:ff:ff
     inet 10.132.0.10/24 brd 10.132.0.255 scope global eth1
        valid_lft forever preferred_lft forever
-    inet6 fe80::e41c:efff:fe12:66ae/64 scope link 
+    inet6 fe80::e41c:efff:fe12:66ae/64 scope link
        valid_lft forever preferred_lft forever
 ```
-Besides your other network interfaces you can already see our new configured interface *eth1* on s1 with the IP 10.132.0.10 which we set in the *vlan.cfg* before.
 
-Continue by doing a simple ping between s1 and s2 to ensure that you indeed have a working connection:
+Next to your other network interfaces, you can already see our newly configured interface _eth1_ on s1 with IP 10.132.0.10, which we previously set in the _vlan.cfg_.
+
+Continue with a simple ping between s1 and s2 to ensure that you actually have a working connection:
+
 ```
 operator@s1:~$ ping 10.132.0.20 -c 5
 
@@ -87,20 +108,30 @@ PING 10.132.0.20 (10.132.0.20) 56(84) bytes of data.
 5 packets transmitted, 5 received, 0% packet loss, time 104ms
 rtt min/avg/max/mdev = 0.379/0.428/0.510/0.053 ms
 ```
-Then also check if the connection also works the other way around from s2 to s1. Now that we have confirmed our vLAN configuration we can continue with the rest of our setup.
+
+Then also check if the connection works in the reverse direction from s2 to s1. Now that we have confirmed our vLAN configuration, we can continue with the rest of our setup.
 
 # Step 2 - Setup Failover IPv4
-## Step 2.1 - Preparation
-### Step 2.1.1 - Log in to your [SCP](https://www.servercontrolpanel.de) either directly or via the [CCP](https://www.customercontrolpanel.de)
-### Step 2.1.2 - Navigate to *Options* (on the top right)
-### Step 2.1.3 - Navigate to *Webservice* (in the left sidebar)
-### Step 2.1.4 - Activate the Webservice and set a secure *Webservice Password*
-### Step 2.1.5 - Assign Failover IP
-We determine that s1 should be our master server and therefore we want to assign the Failover IP to s1: Open the SCP, make sure to choose s1 and then navigate to *Network* in the left sidebar. You should see your Failover IPv4 in the IPv4 Section. Assign it to your server by clicking on *Route IP to Server*.
-## Step 2.2 - Call Webservice to change routing
-We now create a script on both servers, which will make a call to the [Netcup Webservice](https://www.netcup-wiki.de/wiki/Netcup_SCP_Webservice) to change the routing of our Failover IP in case of an error situation. This script is needed in our keepalived configuration which you will see in a moment.
 
-**to\_master.sh**
+## Step 2.1 - Preparation
+
+### Step 2.1.1 - Log in to your [SCP](https://www.servercontrolpanel.de) either directly or via the [CCP](https://www.customercontrolpanel.de).
+
+### Step 2.1.2 - Navigate to _Options_ (on the top right side).
+
+### Step 2.1.3 - Navigate to _Webservice_ (in the left sidebar).
+
+### Step 2.1.4 - Activate the Webservice and set a secure _Webservice Password_.
+
+### Step 2.1.5 - Assign Failover IP.
+
+We determine that s1 should be our master server and therefore we want to assign the Failover IP to s1: Open the SCP, make sure to choose s1 and then navigate to _Network_ in the left sidebar. You should see your Failover IPv4 in the IPv4 section. Assign it to your server by clicking on _Route IP to Server_.
+
+## Step 2.2 - Call netcup Webservice to change routing
+
+We now create a script on both servers that will make a call to the [netcup Webservice](https://www.netcup-wiki.de/wiki/Netcup_SCP_Webservice) to change the routing of our Failover IP in case of an error situation. This script is needed in our Keepalived configuration, which you will see in a moment.
+
+**to_master.sh**
 
 ```
 #!/usr/bin/bash
@@ -144,35 +175,45 @@ do
     n=$((n+1))
 done
 ```
+
 The above script changes the routing of the Failover IPv4 to the specified server. If the rerouting does not work for any reason, the script tries again until the maximum tries (in this case 10) are reached. Make sure to use your actual data wherever needed and to make the script executable with `sudo chmod +x to_master.sh`.
 
 Hints:
-- *YOUR\_LOGIN\_NAME* is your customer id.
-- *YOUR\_WEBSERVICE\_PASSWORD* is the one we just set in step 2.1.4
-- *YOUR\_FAILOVER\_IP* can be found in your CCP in the section *Products* or in the SCP in the *Network* section
-- *YOUR\_VSERVER\_NAME* can be found in your SCP in the *General* section of the corresponding server
-- *YOUR\_VSERVER\_MAC* can also be found in your SCP in the *General* section of the corresponding server (Note that you need the MAC of your primary interface not the MAC of the vLAN)
 
-# Step 3 - Setup keepalived
-## Step 3.1 - Install keepalived
-Navigate to either the website [https://keepalived.org/download.html](https://keepalived.org/download.html) or the respective GitHub repository [https://github.com/acassen/keepalived](https://github.com/acassen/keepalived) and install the application as per the instructions available at [https://github.com/acassen/keepalived/blob/master/INSTALL](https://github.com/acassen/keepalived/blob/master/INSTALL).
-## Step 3.2 - Turn on Packet forwarding
-In order for the keepalived service to forward packets you need to turn on forwarding in the kernel. Edit `/etc/sysctl.conf` and make sure to include the following line using your favourite text editor e.g. `sudo vim /etc/sysctl.conf`:
+- _YOUR_LOGIN_NAME_ is your customer id.
+- _YOUR_WEBSERVICE_PASSWORD_ is the one we just set in step 2.1.4.
+- _YOUR_FAILOVER_IP_ can be found in your CCP in the _Products_ section or in the SCP in the _Network_ section.
+- _YOUR_VSERVER_NAME_ can be found in your SCP in the _General_ section of the corresponding server.
+- _YOUR_VSERVER_MAC_ can also be found in your SCP in the _General_ section of the corresponding server (note that you need the MAC of your primary interface not the MAC of the vLAN).
+
+# Step 3 - Set up Keepalived
+
+## Step 3.1 - Install Keepalived
+
+Navigate to either the website [https://keepalived.org/download.html](https://keepalived.org/download.html) or the respective GitHub repository [https://github.com/acassen/keepalived](https://github.com/acassen/keepalived) and install the application. The instructions are available at [https://github.com/acassen/keepalived/blob/master/INSTALL](https://github.com/acassen/keepalived/blob/master/INSTALL).
+
+## Step 3.2 - Turn on packet forwarding
+
+In order for the Keepalived service to forward packets, you need to turn on forwarding in the kernel. Edit `/etc/sysctl.conf` and make sure to include the following line using your favorite text editor, e.g. `sudo vim /etc/sysctl.conf`:
+
 ```
 net.ipv4.ip_forward = 1
 ```
-For the changes to take effect execute `sudo sysctl -p`
 
-## Step 3.3 - Configure keepalived
-I will provide a basic configuration here which is a good starting point for further tweaks if needed. With this configuration s1 starts as master and s2 starts as backup. If s1 is for any reason not sending adverts anymore / s2 does not receive adverts anymore, s2 will automatically jump in as a failover.
+For the changes to take effect execute `sudo sysctl -p`.
 
-One interesting parameter to start tweaking is the *advert\_int* parameter. This parameter on the one hand determines how often an advert should be sent (every 2 seconds in this case) and on the other hand determines that if after 3 * *advert\_int* seconds no advert was received the failover is triggered (so in this case; after 3 * 2 = 6 seconds).
+## Step 3.3 - Configure Keepalived
 
-If a server changes from BACKUP to MASTER state the *notify\_master* script, which is our *to\_master.sh* (that reroutes our Failover IPv4), is triggered.
+I will provide a basic configuration here that is a good starting point for further tweaks if needed. In this configuration, s1 starts as master and s2 starts as backup. If for some reason s1 stops sending adverts / s2 stops receiving adverts, s2 will automatically jump in as failover.
 
-But there are much more methods you can use to trigger a failover besides the adverts. You could for example also track files, scripts, processes, interfaces etc. to increase/decrease the priority and trigger the failover based on this. Especially scripts arev very flexible and offer the possibility for more sophisticated checks. If you are interested in more configuration methods this [Red Hat Article](https://www.redhat.com/sysadmin/advanced-keepalived) covers some configurations.
+An interesting parameter to start working on is the _advert_int_ parameter. On the one hand, this parameter defines how often an advert should be sent (in this case every 2 seconds) and, on the other hand, that if no advert has been received after 3 \* _advert_int_ seconds, the failover is triggered (so in this case; after 3 \* 2 = 6 seconds).
 
-**Example */etc/keepalived/keepalived.conf* for s1**
+If a server changes from BACKUP to MASTER state, the _notify_master_ script is triggered, which is our _to_master.sh_ (the one that reroutes our Failover IPv4).
+
+However, there are many more methods besides adverts that you can use to trigger a failover. For example, you could also track files, scripts, processes, interfaces, etc. to increase/decrease priority and trigger the failover based on that. Scripts in particular are very flexible and offer the possibility for more sophisticated checks. If you are interested in more configuration methods, see this [Red Hat Article](https://www.redhat.com/sysadmin/advanced-keepalived) for some configurations.
+
+**Example _/etc/keepalived/keepalived.conf_ for s1**
+
 ```
 vrrp_instance VI_1 {
     state MASTER
@@ -191,7 +232,8 @@ vrrp_instance VI_1 {
 }
 ```
 
-**Example */etc/keepalived/keepalived.conf* for s2**
+**Example _/etc/keepalived/keepalived.conf_ for s2**
+
 ```
 vrrp_instance VI_1 {
     state BACKUP
@@ -209,36 +251,41 @@ vrrp_instance VI_1 {
     notify_master /PATH/TO/YOUR/SCRIPT/to_master.sh
 }
 ```
-Note: The *CUSTOM\_PASSWORD* should be a secure password set by you and must be the same for s1 and s2.
 
-## Step 3.4 - Restart keepalived
+Note: The _CUSTOM_PASSWORD_ should be a secure password set by you and must be the same for s1 and s2.
+
+## Step 3.4 - Restart Keepalived
+
 ```
 sudo systemctl restart keepalived
 ```
 
 # Conclusion
-You should now have a running configuration of keepalived, which automatically triggers a rerouting of your Failover IPv4 to a backup server if the master server is down. You can verify if your system is set up correctly by turning s1 off while watching if s2 detects that failure situation and reroutes the Failover IPv4. 
+
+You should now have a running configuration of Keepalived that automatically triggers a rerouting of your Failover IPv4 to a backup server if the master server is down. You can verify that your system is set up correctly by turning off s1 and observing whether s2 detects the failure situation and reroutes the Failover IPv4.
 
 Some additional remarks:
-- If you have any problems with keepalived you may want to review your firewall settings and make sure that VRRP (protocol 112) is allowed. 
-- You can check `sudo tcpdump proto 112 -i eth1` to see if the servers are receiving each others adverts.
-- There are many keepalived configuration options to play around with. I highly recommend to read deeper into it if you need something that is not covered by this tutorial.
+
+- If you have any problems with Keepalived, you may want to review your firewall settings and make sure that VRRP (protocol 112) is allowed.
+- You can check `sudo tcpdump proto 112 -i eth1` to verify that the servers are receiving each other's adverts.
+- There are many Keepalived configuration options to play around with. I highly recommend digging deeper if you need something that is not covered in this tutorial.
 - There is always a sweet spot between short downtime in case of a failover and the prevention of false or frequent failovers due to overly strict constraints (flapping).
-- It should be noted that the call to the webservice and the rerouting of the Failover IP may take several seconds.
+- It should be noted that the call to the netcup Webservice and the rerouting of the Failover IPv4 may take several seconds.
 
 # License
+
 MIT
 
 # Contributor's Certificate of Origin
-Contributor's Certificate of Origin By making a contribution to this project, I certify that:
 
- 1) The contribution was created in whole or in part by me and I have the right to submit it under the license indicated in the file; or
+By making a contribution to this project, I certify that:
 
- 2) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same license (unless I am permitted to submit under a different license), as indicated in the file; or
+1.  The contribution was created in whole or in part by me and I have the right to submit it under the license indicated in the file; or
 
- 3) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+2.  The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same license (unless I am permitted to submit under a different license), as indicated in the file; or
 
- 4) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the license(s) involved.
+3.  The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
 
-Signed-off-by: Marcel Pabst [pabstmarcel95@gmail.com](mailto:pabstmarcel95@gmail.com)
+4.  I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the license(s) involved.
 
+Signed off by: Marcel Pabst [pabstmarcel95@gmail.com](mailto:pabstmarcel95@gmail.com)

--- a/community-tutorials/high-availability-keepalived/01-en.md
+++ b/community-tutorials/high-availability-keepalived/01-en.md
@@ -14,39 +14,40 @@ available_languages: en
 ---
 
 # Introduction
-High-availability (HA) refers to the ability of a system to continue operating with a high probability despite the failure of one of its components. There are several applications that help us to achieve high-availability. In this tutorial we will use [keepalived](https://github.com/acassen/keepalived) an application for loadbalancing and high-availability, which uses the Virtual Router Redundancy Protocol (VRRP). 
+High-availability (HA) refers to the ability of a system to continue operating with a high probability despite the failure of one of its components. There are several applications that help us to achieve high-availability. In this tutorial we will use [keepalived](https://github.com/acassen/keepalived) an application for loadbalancing and high-availability, which uses the Virtual Router Redundancy Protocol (VRRP; [RFC5798](https://datatracker.ietf.org/doc/html/rfc5798)). 
 
 Keepalived is used as a daemon that monitors the system state or certain conditions to automatically failover to a standby system if an error occurs. We will additionally use a [Netcup Failover-IPv4](https://www.netcup.de/bestellen/produkt.php?produkt=1073) and a [Cloud vLAN Free](https://www.netcup.de/bestellen/produkt.php?produkt=2284).
 
-Please note that this is not an absolute beginners tutorial. I use references to other tutorials or the official documentation of used applications. If there are already instructions, I see no reason to write them again. So the main point here is how to achieve high availability with the mentioned products in the Netcup environment.
+Please note that this is not an absolute beginners tutorial. I use references to other tutorials or the official documentation of used applications. If there are already instructions, I see no reason to write them again. So the main point here is how to implement a high availability setup with the mentioned products in the Netcup environment.
 
 # Requirements
 - Two Servers either [vServers](https://www.netcup.de/vserver/vps.php) or [Root Servers](https://www.netcup.de/vserver/) with Ubuntu/Debian
 - [Failover IPv4](https://www.netcup.de/bestellen/produkt.php?produkt=1073)
 - [Cloud vLAN Free](https://www.netcup.de/bestellen/produkt.php?produkt=2284) (or higher)
-- Access to your Customer Control Panel (CCP) & Server Control Panel (SCP)
+- Access to your [Customer Control Panel (CCP)](https://www.customercontrolpanel.de) & [Server Control Panel (SCP)](https://www.servercontrolpanel.de)
 - Access to a user with root privileges 
 
 I assume that you have already booked the mentioned products and fulfill the stated requirements. I will simply refer to the two servers as server 1 (s1) and server 2 (s2). If I am not stating a specific server it means that the commands need to be executed on both servers.
 
 # Step 1 - Setup Cloud vLAN
 ## Step 1.1 - Preparation SCP
-### Step 1.1.1 - Log in to your [SCP](https://www.servercontrolpanel.de) either directly or via the [CCP](https://www.customercontrolpanel.de)
+### Step 1.1.1 - Log in to your [SCP](https://www.servercontrolpanel.de), either directly or via the autologin feature in your [CCP](https://www.customercontrolpanel.de)
 ### Step 1.1.2 - Choose a server (from the list on the top left) 
-### Step 1.1.3 - Navigate to the "Network" section
-### Step 1.1.4 - Choose "add Ethernet Interface" on the top right
-### Step 1.1.5 - Select your Cloud vLAN and choose "virtio" as the driver
+### Step 1.1.3 - Navigate to the *Network* section (in the left sidebar)
+### Step 1.1.4 - Choose *add Ethernet Interface* (on the top right)
+### Step 1.1.5 - Select your Cloud vLAN and choose *virtio* as the driver
 ### Step 1.1.6 - Select the second server and repeat the steps 1.1.3 - 1.1.5; then continue with 1.2
 ## Step 1.2 - Create interface
 Log in to your servers and create a vLAN-configuration for the network interface via your favourite text editor e.g. `sudo vim /etc/network/interfaces.d/vlan.cfg`
-Example Configuration for s1:
+
+**Example */etc/network/interfaces.d/vlan.cfg* for s1**
 ```
 auto eth1
 iface eth1 inet static
     address 10.132.0.10
     netmask 255.255.255.0
 ```
-Example Configuration for s2:
+**Example */etc/network/interfaces.d/vlan.cfg* for s2**
 ```
 auto eth1
 iface eth1 inet static
@@ -57,7 +58,7 @@ iface eth1 inet static
 ```
 sudo systemctl restart networking
 ```
-## Step 1.4 - Verify that your vLAN is set up properly
+## Step 1.4 - Verify vLAN Setup
 There are various methods to verify if your vLAN is setup correctly. You could for example start with a simple check via `ip addr show`:
 ```
 3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
@@ -67,9 +68,9 @@ There are various methods to verify if your vLAN is setup correctly. You could f
     inet6 fe80::e41c:efff:fe12:66ae/64 scope link 
        valid_lft forever preferred_lft forever
 ```
-Besides your other network interfaces you can already see our new configured interface "eth1" on s1 with the IP 10.132.0.10 which we set in the vlan.cfg before.
+Besides your other network interfaces you can already see our new configured interface *eth1* on s1 with the IP 10.132.0.10 which we set in the *vlan.cfg* before.
 
-You could continue by doing a simple ping between s1 and s2 to ensure that you indeed have a working connection:
+Continue by doing a simple ping between s1 and s2 to ensure that you indeed have a working connection:
 ```
 operator@s1:~$ ping 10.132.0.20 -c 5
 
@@ -84,20 +85,21 @@ PING 10.132.0.20 (10.132.0.20) 56(84) bytes of data.
 5 packets transmitted, 5 received, 0% packet loss, time 104ms
 rtt min/avg/max/mdev = 0.379/0.428/0.510/0.053 ms
 ```
-You could then also check if the connection also works the other way around from s2 to s1. Now that we have confirmed our vLAN configuration we can continue with the rest of our setup.
+Then also check if the connection also works the other way around from s2 to s1. Now that we have confirmed our vLAN configuration we can continue with the rest of our setup.
 
 # Step 2 - Setup Failover IPv4
 ## Step 2.1 - Preparation
 ### Step 2.1.1 - Log in to your [SCP](https://www.servercontrolpanel.de) either directly or via the [CCP](https://www.customercontrolpanel.de)
-### Step 2.1.2 - Navigate to "Options" in the top right corner
-### Step 2.1.3 - Navigate to "Webservice" in the left sidebar
-### Step 2.1.4 - Activate the Webservice and set a secure "Webservice Password"
-### Step 2.1.5 - Assign Failover IP to s1
-We determine that s1 should be our master server and therefore we want to assign the Failover IP to s1: Open the SCP, make sure to choose s1 and then navigate to "Network" in the left sidebar. You should see your Failover IPv4 in the IPv4 Section. Assign it to your server by clicking on "Route IP to Server".
-## Step 2.2 - Create scripts to reroute the Failover IP
-We now create a script on both servers, which will make a call to the [Netcup Webservice](https://www.netcup-wiki.de/wiki/Netcup_SCP_Webservice) to reroute our Failover IP in case of an error situation. This script is needed in our keepalived configuration which you will see in a moment.
+### Step 2.1.2 - Navigate to *Options* (on the top right)
+### Step 2.1.3 - Navigate to *Webservice* (in the left sidebar)
+### Step 2.1.4 - Activate the Webservice and set a secure *Webservice Password*
+### Step 2.1.5 - Assign Failover IP
+We determine that s1 should be our master server and therefore we want to assign the Failover IP to s1: Open the SCP, make sure to choose s1 and then navigate to *Network* in the left sidebar. You should see your Failover IPv4 in the IPv4 Section. Assign it to your server by clicking on *Route IP to Server*.
+## Step 2.2 - Call Webservice to change routing
+We now create a script on both servers, which will make a call to the [Netcup Webservice](https://www.netcup-wiki.de/wiki/Netcup_SCP_Webservice) to change the routing of our Failover IP in case of an error situation. This script is needed in our keepalived configuration which you will see in a moment.
 
-to\_master.sh
+**to\_master.sh**
+
 ```
 #!/usr/bin/bash
 
@@ -143,15 +145,15 @@ done
 The above script changes the routing of the Failover IPv4 to the specified server. If the rerouting does not work for any reason, the script tries again until the maximum tries (in this case 10) are reached. Make sure to use your actual data wherever needed and to make the script executable with `sudo chmod +x to_master.sh`.
 
 Hints:
-- YOUR\_LOGIN\_NAME is your customer id.
-- YOUR\_WEBSERVICE\_PASSWORD is the one we just set in step 2.1.4
-- YOUR\_FAILOVER\_IP can be found in your CCP in the section products or in the SCP in the "Network" section
-- YOUR\_VSERVER\_NAME can be found in your SCP in the "General" section of the corresponding server
-- YOUR\_VSERVER\_MAC can also be found in your SCP in the "General" section of the corresponding server (Note that you need the MAC of your primary interface not the MAC of the vLAN)
+- *YOUR\_LOGIN\_NAME* is your customer id.
+- *YOUR\_WEBSERVICE\_PASSWORD* is the one we just set in step 2.1.4
+- *YOUR\_FAILOVER\_IP* can be found in your CCP in the section *Products* or in the SCP in the *Network* section
+- *YOUR\_VSERVER\_NAME* can be found in your SCP in the *General* section of the corresponding server
+- *YOUR\_VSERVER\_MAC* can also be found in your SCP in the *General* section of the corresponding server (Note that you need the MAC of your primary interface not the MAC of the vLAN)
 
 # Step 3 - Setup keepalived
 ## Step 3.1 - Install keepalived
-Navigate to either the website [https://keepalived.org/download.html](https://keepalived.org/download.html) or the respective GitHub repository [https://github.com/acassen/keepalived](https://github.com/acassen/keepalived) and install the application as per the instructions available [https://github.com/acassen/keepalived/blob/master/INSTALL](https://github.com/acassen/keepalived/blob/master/INSTALL).
+Navigate to either the website [https://keepalived.org/download.html](https://keepalived.org/download.html) or the respective GitHub repository [https://github.com/acassen/keepalived](https://github.com/acassen/keepalived) and install the application as per the instructions available at [https://github.com/acassen/keepalived/blob/master/INSTALL](https://github.com/acassen/keepalived/blob/master/INSTALL).
 ## Step 3.2 - Turn on Packet forwarding
 In order for the keepalived service to forward packets you need to turn on forwarding in the kernel. Edit `/etc/sysctl.conf` and make sure to include the following line using your favourite text editor e.g. `sudo vim /etc/sysctl.conf`:
 ```
@@ -159,16 +161,16 @@ net.ipv4.ip_forward = 1
 ```
 For the changes to take effect execute `sudo sysctl -p`
 
-## Step 3.3 - Adjust /etc/keepalived/keepalived.conf
-I will provide a basic configuration here which is a good starting point for further tweaks if needed. With this configuration s1 starts as master and s2 starts as backup. If s1 is for any reason not sending adverts anymore / s2 do not receives adverts anymore, s2 will automatically jump in as a failover.
+## Step 3.3 - Configure keepalived
+I will provide a basic configuration here which is a good starting point for further tweaks if needed. With this configuration s1 starts as master and s2 starts as backup. If s1 is for any reason not sending adverts anymore / s2 does not receive adverts anymore, s2 will automatically jump in as a failover.
 
-One interesting parameter to start tweaking is the "advert\_int" parameter. This parameter on the one hand determines how often an advert should be sent (every 2 seconds in this case) and on the other hand determines that if after 3 * advert\_int seconds no advert was received the failover is triggered (so in this case; after 3 * 2 = 6 seconds).
+One interesting parameter to start tweaking is the *advert\_int* parameter. This parameter on the one hand determines how often an advert should be sent (every 2 seconds in this case) and on the other hand determines that if after 3 * *advert\_int* seconds no advert was received the failover is triggered (so in this case; after 3 * 2 = 6 seconds).
 
-If a server changes from BACKUP to MASTER state the notify\_master script, which is our "to\_master.sh" (that reroutes our Failover IPv4), is triggered.
+If a server changes from BACKUP to MASTER state the *notify\_master* script, which is our *to\_master.sh* (that reroutes our Failover IPv4), is triggered.
 
 But there are much more methods you can use to trigger a failover besides the adverts. You could for example also track files, scripts, processes, interfaces etc. to increase/decrease the priority and trigger the failover based on this. Especially scripts arev very flexible and offer the possibility for more sophisticated checks. If you are interested in more configuration methods this [Red Hat Article](https://www.redhat.com/sysadmin/advanced-keepalived) covers some configurations.
 
-### Step 3.3.1 - Configuration for s1
+**Example */etc/keepalived/keepalived.conf* for s2**
 ```
 vrrp_instance VI_1 {
     state MASTER
@@ -178,7 +180,7 @@ vrrp_instance VI_1 {
     advert_int 2
     authentication {
         auth_type PASS
-        auth_pass CUSTOM_PASSWORD_SAME_FOR_S1_S2
+        auth_pass CUSTOM_PASSWORD
     }
     virtual_ipaddress {
         10.132.0.100
@@ -186,7 +188,8 @@ vrrp_instance VI_1 {
     notify_master /PATH/TO/YOUR/SCRIPT/to_master.sh
 }
 ```
-### Step 3.3.2 - Configuration for s2
+
+**Example */etc/keepalived/keepalived.conf* for s2**
 ```
 vrrp_instance VI_1 {
     state BACKUP
@@ -196,7 +199,7 @@ vrrp_instance VI_1 {
     advert_int 2
     authentication {
         auth_type PASS
-        auth_pass CUSTOM_PASSWORD_SAME_FOR_S1_S2
+        auth_pass CUSTOM_PASSWORD
     }
     virtual_ipaddress {
         10.132.0.100
@@ -204,6 +207,8 @@ vrrp_instance VI_1 {
     notify_master /PATH/TO/YOUR/SCRIPT/to_master.sh
 }
 ```
+Note: The *CUSTOM\_PASSWORD* should be a secure password set by you and must be the same for s1 and s2.
+
 ## Step 3.4 - Restart keepalived
 ```
 sudo systemctl restart keepalived

--- a/community-tutorials/high-availability-keepalived/01-en.md
+++ b/community-tutorials/high-availability-keepalived/01-en.md
@@ -7,7 +7,7 @@ author_name: Marcel Pabst
 author_url: -
 author_image: -
 author_bio: -
-tags: [debian, ubuntu, vserver, rootserver, failover, keepalived, high-availability, vlan]
+tags: [debian, vserver, rootserver, failover, keepalived, high-availability, vlan]
 netcup_product_url: https://www.netcup.de/vserver/vps.phpi, https://www.netcup.de/vserver/, https://www.netcup.de/bestellen/produkt.php?produkt=1073, https://www.netcup.de/bestellen/produkt.php?produkt=2284
 language: en
 available_languages: en
@@ -20,8 +20,10 @@ Keepalived is used as a daemon that monitors the system state or certain conditi
 
 Please note that this is not an absolute beginners tutorial. I use references to other tutorials or the official documentation of used applications. If there are already instructions, I see no reason to write them again. So the main point here is how to implement a high availability setup with the mentioned products in the Netcup environment.
 
+This tutorial may also be used as a starting point for other distributions but some modifications will be neccessary. 
+
 # Requirements
-- Two Servers either [vServers](https://www.netcup.de/vserver/vps.php) or [Root Servers](https://www.netcup.de/vserver/) with Ubuntu/Debian
+- Two Servers either [vServers](https://www.netcup.de/vserver/vps.php) or [Root Servers](https://www.netcup.de/vserver/) with Debian
 - [Failover IPv4](https://www.netcup.de/bestellen/produkt.php?produkt=1073)
 - [Cloud vLAN Free](https://www.netcup.de/bestellen/produkt.php?produkt=2284) (or higher)
 - Access to your [Customer Control Panel (CCP)](https://www.customercontrolpanel.de) & [Server Control Panel (SCP)](https://www.servercontrolpanel.de)

--- a/community-tutorials/high-availability-keepalived/01-en.md
+++ b/community-tutorials/high-availability-keepalived/01-en.md
@@ -1,0 +1,216 @@
+---
+title: High-Availability with keepalived and Failover IP
+description: This tutorial describes the setup process of a high-availability cluster with keepalived and a Failover IP
+updated_at: 2021-11-09
+slug: high-availability-keepalived-failover
+author_name: Marcel Pabst
+author_url: -
+author_image: -
+author_bio: -
+tags: debian, ubuntu, vserver, rootserver, failover, keepalived, high-availability, vlan
+netcup_product_url: https://www.netcup.de/vserver/vps.phpi, https://www.netcup.de/vserver/, https://www.netcup.de/bestellen/produkt.php?produkt=1073, https://www.netcup.de/bestellen/produkt.php?produkt=2284
+language: en
+available_languages: en
+---
+
+# Introduction
+High-availability (HA) refers to the ability of a system to continue operating with a high probability despite the failure of one of its components. There are several applications that help us to achieve high-availability. In this tutorial we will use [keepalived](https://github.com/acassen/keepalived) an application for loadbalancing and high-availability, which uses the Virtual Router Redundancy Protocol (VRRP). 
+
+Keepalived is used as a daemon that monitors the system state or certain conditions to automatically failover to a standby system if an error occurs. We will additionally use a [Netcup Failover-IPv4](https://www.netcup.de/bestellen/produkt.php?produkt=1073) and a [Cloud vLAN Free](https://www.netcup.de/bestellen/produkt.php?produkt=2284).
+
+Please note that this is not an absolute beginners tutorial. I use references to other tutorials or the official documentation of used applications. If there are already instructions, I see no reason to write them again. So the main point here is how to achieve high availability with the mentioned products in the Netcup environment.
+
+# Requirements
+- Two Servers either [vServers](https://www.netcup.de/vserver/vps.php) or [Root Servers](https://www.netcup.de/vserver/) with Ubuntu/Debian
+- [Failover IPv4](https://www.netcup.de/bestellen/produkt.php?produkt=1073)
+- [Cloud vLAN Free](https://www.netcup.de/bestellen/produkt.php?produkt=2284) (or higher)A
+- Access to your Customer Control Panel (CCP) & Server Control Panel (SCP)
+- Access to a user with root privileges 
+- Access to the Netcup Webservice
+
+I assume that you have already booked the mentioned products and fulfill the stated requirements. I will simply refer to the two servers as server 1 (s1) and server 2 (s2). If I am not stating a specific server it means that the commands need to be executed on both servers.
+
+# Step 1 - Setup Cloud vLAN
+## Step 1.1 - Log in to your [SCP](https://www.servercontrolpanel.de) either directly or via the [CCP](https://www.customercontrolpanel.de)
+## Step 1.2 - Navigate to the network section
+## Step 1.3 - Choose "add Ethernet Interface"
+## Step 1.4 - Select your Cloud vLAN and choose virtio as the driver
+## Step 1.5 - Select the second server and repeat the steps 1.2 - 1.4
+## Step 1.6 - Log in to your servers and create a vLAN-configuration for the network interface via your favourite text editor e.g. `sudo vim /etc/network/interfaces.d/vlan.cfg`
+Example Configuration for s1:
+```
+auto eth1
+iface eth1 inet static
+    address 10.132.0.10
+    netmask 255.255.255.0
+```
+Example Configuration for s2:
+```
+auto eth1
+iface eth1 inet static
+    address 10.132.0.20
+    netmask 255.255.255.0
+```
+## Step 1.7 - Restart networking `sudo systemctl restart networking`
+## Step 1.8 - Verify that your vLAN is set up properly
+There are various methods to verify if your vLAN is setup correctly. You could for example start with a simple check via `ip addr show`:
+```
+3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+    link/ether e6:1c:ef:12:66:ae brd ff:ff:ff:ff:ff:ff
+    inet 10.132.0.10/24 brd 10.132.0.255 scope global eth1
+       valid_lft forever preferred_lft forever
+    inet6 fe80::e41c:efff:fe12:66ae/64 scope link 
+       valid_lft forever preferred_lft forever
+```
+Here you can already see our new configured network on s1 with the IP 10.132.0.10 which we setup in the vlan.cfg before.
+
+You could continue by doing a simple ping between s1 and s2 to ensure that you indeed have a working connection:
+```
+operator@s1:~$ ping 10.132.0.20 -c 5
+
+PING 10.132.0.20 (10.132.0.20) 56(84) bytes of data.
+64 bytes from 10.132.0.20: icmp_seq=1 ttl=64 time=0.450 ms
+64 bytes from 10.132.0.20: icmp_seq=2 ttl=64 time=0.510 ms
+64 bytes from 10.132.0.20: icmp_seq=3 ttl=64 time=0.403 ms
+64 bytes from 10.132.0.20: icmp_seq=4 ttl=64 time=0.379 ms
+64 bytes from 10.132.0.20: icmp_seq=5 ttl=64 time=0.402 ms
+
+--- 10.132.0.20 ping statistics ---
+5 packets transmitted, 5 received, 0% packet loss, time 104ms
+rtt min/avg/max/mdev = 0.379/0.428/0.510/0.053 ms
+```
+Now that we have confirmed our vLAN configuration we can continue with the rest of our setup.
+
+# Step 2 - Setup Failover IPv4
+Hint: You can find your Failover IPv4 in your CCP in the section products.
+## Step 2.1 - Assign Failover IP to s1
+We specify that s1 is our master server and therefore want to assign the Failover IP to s1: Open the SCP, make sure to choose s1 and then navigate to "Network". You should see your Failover IPv4 in the IPv4 Section. Assign it to your server by clicking on "Route IP to Server".
+## Step 2.2 - Create scripts to reroute the Failover IP
+We now create a script on both servers, which will make a call to the Netcup Webservice to reroute our Failover IP in case of an error situation. This script is needed in our keepalived configuration which you will see in a moment.
+
+to\_master.sh
+```
+#!/usr/bin/bash
+
+CURL_REROUTE='
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://enduser.service.web.vcp.netcup.de/">
+    <SOAP-ENV:Body>
+        <ns1:changeIPRouting>
+            <loginName>YOUR_LOGIN_NAME</loginName>
+            <password>YOUR_WEBSERVICE_PASSWORD</password>
+            <routedIP>YOUR_FAILOVER_IP</routedIP>
+            <routedMask>32</routedMask>
+            <destinationVserverName>YOUR_VSERVER_NAME</destinationVserverName>
+            <destinationInterfaceMAC>YOUR_VSERVER_MAC</destinationInterfaceMAC>
+        </ns1:changeIPRouting>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>'
+
+CURL_CHECK='
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://enduser.service.web.vcp.netcup.de/">
+    <SOAP-ENV:Body>
+        <ns1:getVServerIPs>
+            <loginName>YOUR_LOGIN_NAME</loginName>
+            <password>YOUR_WEBSERVICE_PASSWORD</password>
+            <vserverName>YOUR_VSERVER_NAME</vserverName>
+        </ns1:getVServerIPs>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>'
+
+REROUTE_RESULT=$(curl -s -H "Content-Type: text/xml; charset=utf-8" -H "SOAPAction:" -d "$CURL_REROUTE" -X POST https://www.servercontrolpanel.de:443/WSEndUser?xsd=1)
+CHECK_RESULT=$(curl -s -H "Content-Type: text/xml; charset=utf-8" -H "SOAPAction:" -d "$CURL_CHECK" -X POST https://www.servercontrolpanel.de:443/WSEndUser?xsd=1)
+FAILOVER_IP_ACTIVE=$(echo $CHECK_RESULT | grep YOUR_FAILOVER_IP | wc -l)
+
+n=0
+while [ $n -lt 10 ] && [ $FAILOVER_IP_ACTIVE -eq 0 ]
+do
+    REROUTE_RESULT=$(curl -s -H "Content-Type: text/xml; charset=utf-8" -H "SOAPAction:" -d "$CURL_REROUTE" -X POST https://www.servercontrolpanel.de:443/WSEndUser?xsd=1)
+    sleep 3
+    CHECK_RESULT=$(curl -s -H "Content-Type: text/xml; charset=utf-8" -H "SOAPAction:" -d "$CURL_CHECK" -X POST https://www.servercontrolpanel.de:443/WSEndUser?xsd=1)
+    FAILOVER_IP_ACTIVE=$(echo $CHECK_RESULT | grep YOUR_FAILOVER_IP | wc -l)
+    n=$((n+1))
+done
+```
+The above script changes the routing of the Failover IPv4 to the specified server. If the rerouting does not work for any reason, the script tries again until the maximum tries n are reached. Make sure to use your actual data wherever needed and to make the script executable with `sudo chmod +x to_master.sh`.
+
+# Step 3 - Setup keepalived
+## Step 3.1 - Install keepalived
+Navigate to either the website [https://keepalived.org/download.html](https://keepalived.org/download.html) or the respective GitHub repository [https://github.com/acassen/keepalived](https://github.com/acassen/keepalived) and install the application as per the instructions available [https://github.com/acassen/keepalived/blob/master/INSTALL](https://github.com/acassen/keepalived/blob/master/INSTALL).
+## Step 3.2 - Turn on Packet forwarding
+In order for the keepalived service to forward packets you need to turn on forwarding in the kernel. Edit `/etc/sysctl.conf` and make sure to include the following line using your favourite text editor e.g. `sudo vim /etc/sysctl.conf`:
+```
+net.ipv4.ip_forward = 1
+```
+For the changes to take effect execute `sudo sysctl -p`
+
+## Step 3.3 - Adjust /etc/keepalived/keepalived.conf
+I will provide a basic configuration here which is a good starting point for further tweaks if needed. With this configuration s1 starts as master and s2 starts as backup. If s1 is for any reason not sending adverts anymore, s2 will automatically jump in as a failover. If a server changes from BACKUP to MASTER state the notify\_master script, which is our "to\_master.sh" (that reroutes our Failover IPv4), is triggered. 
+
+But there are much more methods:You could for example also track files, scripts, processes, interfaces etc. to increase/decrease the priority and trigger the failover based on this. If you are interested in more configuration methods this [Red Hat Article](https://www.redhat.com/sysadmin/advanced-keepalived) covers some configurations.
+
+### Step 3.3.1 - Configuration for s1
+```
+vrrp_instance VI_1 {
+    state MASTER
+    interface eth1
+    virtual_router_id 101
+    priority 255
+    advert_int 2
+    authentication {
+        auth_type PASS
+        auth_pass CUSTOM_PASSWORD_SAME_FOR_S1_S2
+    }
+    virtual_ipaddress {
+        10.132.0.100
+    }
+    notify_master /PATH/TO/YOUR/SCRIPT/to_master.sh
+}
+```
+### Step 3.3.2 - Configuration for s2
+```
+vrrp_instance VI_1 {
+    state BACKUP
+    interface eth1
+    virtual_router_id 101
+    priority 254
+    advert_int 2
+    authentication {
+        auth_type PASS
+        auth_pass CUSTOM_PASSWORD_SAME_FOR_S1_S2
+    }
+    virtual_ipaddress {
+        10.132.0.100
+    }
+    notify_master /PATH/TO/YOUR/SCRIPT/to_master.sh
+}
+```
+## Step 3.4 - Restart keepalived
+```
+sudo systemctl restart keepalived
+```
+
+# Conclusion
+You should now have a running configuration of keepalived, which automatically triggers a rerouting of your Failover IPv4 to a backup server if the master server is down. You can verify if your system is set up correctly by turning s1 off while watching if s2 detects that failure situation and reroutes the Failover IPv4. 
+
+
+Some additional remarks:
+- If you have any problems with keepalived you may want to review your firewall settings and make sure that VRRP (protocol 112) is allowed. 
+- You can check `sudo tcpdump proto 112 -i eth1` to see if the servers are receiving each others adverts.
+- There are many keepalived configuration options to play arount with. I highly recommend to read deeper into it if you need something that is not covered by this tutorial.
+
+# License
+MIT
+
+# Contributor's Certificate of Origin
+Contributor's Certificate of Origin By making a contribution to this project, I certify that:
+
+ 1) The contribution was created in whole or in part by me and I have the right to submit it under the license indicated in the file; or
+
+ 2) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same license (unless I am permitted to submit under a different license), as indicated in the file; or
+
+ 3) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+
+ 4) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the license(s) involved.
+
+Signed-off-by: Marcel Pabst [pabstmarcel95@gmail.com](mailto:pabstmarcel95@gmail.com)
+

--- a/community-tutorials/high-availability-keepalived/01-en.md
+++ b/community-tutorials/high-availability-keepalived/01-en.md
@@ -7,7 +7,7 @@ author_name: Marcel Pabst
 author_url: -
 author_image: -
 author_bio: -
-tags: debian, ubuntu, vserver, rootserver, failover, keepalived, high-availability, vlan
+tags: [debian, ubuntu, vserver, rootserver, failover, keepalived, high-availability, vlan]
 netcup_product_url: https://www.netcup.de/vserver/vps.phpi, https://www.netcup.de/vserver/, https://www.netcup.de/bestellen/produkt.php?produkt=1073, https://www.netcup.de/bestellen/produkt.php?produkt=2284
 language: en
 available_languages: en
@@ -23,20 +23,22 @@ Please note that this is not an absolute beginners tutorial. I use references to
 # Requirements
 - Two Servers either [vServers](https://www.netcup.de/vserver/vps.php) or [Root Servers](https://www.netcup.de/vserver/) with Ubuntu/Debian
 - [Failover IPv4](https://www.netcup.de/bestellen/produkt.php?produkt=1073)
-- [Cloud vLAN Free](https://www.netcup.de/bestellen/produkt.php?produkt=2284) (or higher)A
+- [Cloud vLAN Free](https://www.netcup.de/bestellen/produkt.php?produkt=2284) (or higher)
 - Access to your Customer Control Panel (CCP) & Server Control Panel (SCP)
 - Access to a user with root privileges 
-- Access to the Netcup Webservice
 
 I assume that you have already booked the mentioned products and fulfill the stated requirements. I will simply refer to the two servers as server 1 (s1) and server 2 (s2). If I am not stating a specific server it means that the commands need to be executed on both servers.
 
 # Step 1 - Setup Cloud vLAN
-## Step 1.1 - Log in to your [SCP](https://www.servercontrolpanel.de) either directly or via the [CCP](https://www.customercontrolpanel.de)
-## Step 1.2 - Navigate to the network section
-## Step 1.3 - Choose "add Ethernet Interface"
-## Step 1.4 - Select your Cloud vLAN and choose virtio as the driver
-## Step 1.5 - Select the second server and repeat the steps 1.2 - 1.4
-## Step 1.6 - Log in to your servers and create a vLAN-configuration for the network interface via your favourite text editor e.g. `sudo vim /etc/network/interfaces.d/vlan.cfg`
+## Step 1.1 - Preparation SCP
+### Step 1.1.1 - Log in to your [SCP](https://www.servercontrolpanel.de) either directly or via the [CCP](https://www.customercontrolpanel.de)
+### Step 1.1.2 - Choose a server (from the list on the top left) 
+### Step 1.1.3 - Navigate to the "Network" section
+### Step 1.1.4 - Choose "add Ethernet Interface" on the top right
+### Step 1.1.5 - Select your Cloud vLAN and choose "virtio" as the driver
+### Step 1.1.6 - Select the second server and repeat the steps 1.1.3 - 1.1.5; then continue with 1.2
+## Step 1.2 - Create interface
+Log in to your servers and create a vLAN-configuration for the network interface via your favourite text editor e.g. `sudo vim /etc/network/interfaces.d/vlan.cfg`
 Example Configuration for s1:
 ```
 auto eth1
@@ -51,8 +53,11 @@ iface eth1 inet static
     address 10.132.0.20
     netmask 255.255.255.0
 ```
-## Step 1.7 - Restart networking `sudo systemctl restart networking`
-## Step 1.8 - Verify that your vLAN is set up properly
+## Step 1.3 - Restart networking 
+```
+sudo systemctl restart networking
+```
+## Step 1.4 - Verify that your vLAN is set up properly
 There are various methods to verify if your vLAN is setup correctly. You could for example start with a simple check via `ip addr show`:
 ```
 3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
@@ -62,7 +67,7 @@ There are various methods to verify if your vLAN is setup correctly. You could f
     inet6 fe80::e41c:efff:fe12:66ae/64 scope link 
        valid_lft forever preferred_lft forever
 ```
-Here you can already see our new configured network on s1 with the IP 10.132.0.10 which we setup in the vlan.cfg before.
+Besides your other network interfaces you can already see our new configured interface "eth1" on s1 with the IP 10.132.0.10 which we set in the vlan.cfg before.
 
 You could continue by doing a simple ping between s1 and s2 to ensure that you indeed have a working connection:
 ```
@@ -79,14 +84,18 @@ PING 10.132.0.20 (10.132.0.20) 56(84) bytes of data.
 5 packets transmitted, 5 received, 0% packet loss, time 104ms
 rtt min/avg/max/mdev = 0.379/0.428/0.510/0.053 ms
 ```
-Now that we have confirmed our vLAN configuration we can continue with the rest of our setup.
+You could then also check if the connection also works the other way around from s2 to s1. Now that we have confirmed our vLAN configuration we can continue with the rest of our setup.
 
 # Step 2 - Setup Failover IPv4
-Hint: You can find your Failover IPv4 in your CCP in the section products.
-## Step 2.1 - Assign Failover IP to s1
-We specify that s1 is our master server and therefore want to assign the Failover IP to s1: Open the SCP, make sure to choose s1 and then navigate to "Network". You should see your Failover IPv4 in the IPv4 Section. Assign it to your server by clicking on "Route IP to Server".
+## Step 2.1 - Preparation
+### Step 2.1.1 - Log in to your [SCP](https://www.servercontrolpanel.de) either directly or via the [CCP](https://www.customercontrolpanel.de)
+### Step 2.1.2 - Navigate to "Options" in the top right corner
+### Step 2.1.3 - Navigate to "Webservice" in the left sidebar
+### Step 2.1.4 - Activate the Webservice and set a secure "Webservice Password"
+### Step 2.1.5 - Assign Failover IP to s1
+We determine that s1 should be our master server and therefore we want to assign the Failover IP to s1: Open the SCP, make sure to choose s1 and then navigate to "Network" in the left sidebar. You should see your Failover IPv4 in the IPv4 Section. Assign it to your server by clicking on "Route IP to Server".
 ## Step 2.2 - Create scripts to reroute the Failover IP
-We now create a script on both servers, which will make a call to the Netcup Webservice to reroute our Failover IP in case of an error situation. This script is needed in our keepalived configuration which you will see in a moment.
+We now create a script on both servers, which will make a call to the [Netcup Webservice](https://www.netcup-wiki.de/wiki/Netcup_SCP_Webservice) to reroute our Failover IP in case of an error situation. This script is needed in our keepalived configuration which you will see in a moment.
 
 to\_master.sh
 ```
@@ -131,7 +140,14 @@ do
     n=$((n+1))
 done
 ```
-The above script changes the routing of the Failover IPv4 to the specified server. If the rerouting does not work for any reason, the script tries again until the maximum tries n are reached. Make sure to use your actual data wherever needed and to make the script executable with `sudo chmod +x to_master.sh`.
+The above script changes the routing of the Failover IPv4 to the specified server. If the rerouting does not work for any reason, the script tries again until the maximum tries (in this case 10) are reached. Make sure to use your actual data wherever needed and to make the script executable with `sudo chmod +x to_master.sh`.
+
+Hints:
+- YOUR\_LOGIN\_NAME is your customer id.
+- YOUR\_WEBSERVICE\_PASSWORD is the one we just set in step 2.1.4
+- YOUR\_FAILOVER\_IP can be found in your CCP in the section products or in the SCP in the "Network" section
+- YOUR\_VSERVER\_NAME can be found in your SCP in the "General" section of the corresponding server
+- YOUR\_VSERVER\_MAC can also be found in your SCP in the "General" section of the corresponding server (Note that you need the MAC of your primary interface not the MAC of the vLAN)
 
 # Step 3 - Setup keepalived
 ## Step 3.1 - Install keepalived
@@ -144,9 +160,13 @@ net.ipv4.ip_forward = 1
 For the changes to take effect execute `sudo sysctl -p`
 
 ## Step 3.3 - Adjust /etc/keepalived/keepalived.conf
-I will provide a basic configuration here which is a good starting point for further tweaks if needed. With this configuration s1 starts as master and s2 starts as backup. If s1 is for any reason not sending adverts anymore, s2 will automatically jump in as a failover. If a server changes from BACKUP to MASTER state the notify\_master script, which is our "to\_master.sh" (that reroutes our Failover IPv4), is triggered. 
+I will provide a basic configuration here which is a good starting point for further tweaks if needed. With this configuration s1 starts as master and s2 starts as backup. If s1 is for any reason not sending adverts anymore / s2 do not receives adverts anymore, s2 will automatically jump in as a failover.
 
-But there are much more methods:You could for example also track files, scripts, processes, interfaces etc. to increase/decrease the priority and trigger the failover based on this. If you are interested in more configuration methods this [Red Hat Article](https://www.redhat.com/sysadmin/advanced-keepalived) covers some configurations.
+One interesting parameter to start tweaking is the "advert\_int" parameter. This parameter on the one hand determines how often an advert should be sent (every 2 seconds in this case) and on the other hand determines that if after 3 * advert\_int seconds no advert was received the failover is triggered (so in this case; after 3 * 2 = 6 seconds).
+
+If a server changes from BACKUP to MASTER state the notify\_master script, which is our "to\_master.sh" (that reroutes our Failover IPv4), is triggered.
+
+But there are much more methods you can use to trigger a failover besides the adverts. You could for example also track files, scripts, processes, interfaces etc. to increase/decrease the priority and trigger the failover based on this. Especially scripts arev very flexible and offer the possibility for more sophisticated checks. If you are interested in more configuration methods this [Red Hat Article](https://www.redhat.com/sysadmin/advanced-keepalived) covers some configurations.
 
 ### Step 3.3.1 - Configuration for s1
 ```
@@ -192,11 +212,12 @@ sudo systemctl restart keepalived
 # Conclusion
 You should now have a running configuration of keepalived, which automatically triggers a rerouting of your Failover IPv4 to a backup server if the master server is down. You can verify if your system is set up correctly by turning s1 off while watching if s2 detects that failure situation and reroutes the Failover IPv4. 
 
-
 Some additional remarks:
 - If you have any problems with keepalived you may want to review your firewall settings and make sure that VRRP (protocol 112) is allowed. 
 - You can check `sudo tcpdump proto 112 -i eth1` to see if the servers are receiving each others adverts.
-- There are many keepalived configuration options to play arount with. I highly recommend to read deeper into it if you need something that is not covered by this tutorial.
+- There are many keepalived configuration options to play around with. I highly recommend to read deeper into it if you need something that is not covered by this tutorial.
+- There is always a sweet spot between short downtime in case of a failover and the prevention of false or frequent failovers due to overly strict constraints (flapping).
+- It should be noted that the call to the webservice and the rerouting of the Failover IP may take several seconds.
 
 # License
 MIT


### PR DESCRIPTION
This adds a tutorial for a (simple) high availability solution using keepalived, Netcup Failover IPv4, Netcup Cloud vLAN and two Netcup vServers or Root Servers. It is intended as a more advanced tutorial where not every step is ellaborated to the smallest detail.

---

I have read and understood the Contributor's Certificate of Origin at the end of the template and I hereby certify that I meet the contribution criteria described in it.

Signed-off-by: Marcel Pabst pabstmarcel95@gmail.com