### PR TITLE
Fixed typo in README.md indefinitely

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # netcup Community Tutorials
-Community contributed tutorials about what can be done with netcup products and services.
+Community-contributed tutorials about what can be done with netcup products and services.
 
 ## Contribution Guidelines
 Please make sure to follow the [Contribution Guidelines](https://github.com/netcup-community/community-tutorials/blob/main/CONTRIBUTING.md) if you want to contribute a tutorial.
 Once done, open a Pull Request. A Repository Maintainer will review your tutorial and either accept it or get back to you with feedback.
 
 ## Rewards
- If your tutorial is accepted, you will receive an E-Mail (sent from our @anexia-it.com addresses) to the address you provide in your tutorial, asking for your netcup customer-ID in order to process your reward of €60,- in the form of netcup vouchers, exclusively for published tutorials.
+ If your tutorial is accepted, you will receive an email (sent from our @anexia-it.com addresses) to the address you provide in your tutorial asking for your netcup customer-ID in order to process your reward of €60,- in the form of netcup vouchers, exclusively for published tutorials.
 
-### Details to vouchers
+### Details about vouchers
 1) Vouchers are not valid for: Domains, SSL Certificates, Groupware and products with hourly billing.
 2) Vouchers can only be used for new orders.
 3) (Minimum) order value needs to be equal to or higher than the voucher is. Example: (Minimum) Order Value for a €20,- voucher is €21,- (Difference of €1,- is to be paid.)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If your tutorial is accepted, you will receive an E-Mail (sent from our @anexia-
 ## Support
 If you need help with a specific tutorial, reach out to the contributor directly or join the netcup Forum for further questions, input and exchange.
 
-You can also request content in the [netcup Forum](https://forum.netcup.de/community-tutorials/community-tutorial-vorschl%C3%A4ge/).
+You can also request content in the [netcup Forum](https://forum.netcup.de/).
 
 If you need help with something else than a tutorial, please make use of our netcup-wiki* or join the netcup Forum.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If your tutorial is accepted, you will receive an E-Mail (sent from our @anexia-
 1) Vouchers are not valid for: Domains, SSL Certificates, Groupware and products with hourly billing.
 2) Vouchers can only be used for new orders.
 3) (Minimum) order value needs to be equal to or higher than the voucher is. Example: (Minimum) Order Value for a €20,- voucher is €21,- (Difference of €1,- is to be paid.)
-4) Vouchers are valid indefinitley.
+4) Vouchers are valid indefinitely.
 5) Vouchers are only valid for products in our regular product portfolio. (e.g.: currently vouchers can't be used to buy a netcup cup.)
 
 ## Support


### PR DESCRIPTION
Update README.md removing not working Forum deep link in the Support section for requesting content:
Shortened https://forum.netcup.de/community-tutorials/community-tutorial-vorschl%C3%A4ge/ because forum link does not exist anymore.
"Die von Ihnen angeforderte Seite wurde nicht gefunden. Bitte überprüfen Sie die Adresse oder gehen Sie zurück auf die Startseite."