### PR TITLE
Fixed typos and shell script errors in tutorial basic-scripting

### DIFF
--- a/community-tutorials/basic-scripting/01-en.md
+++ b/community-tutorials/basic-scripting/01-en.md
@@ -116,7 +116,7 @@ then
 fi
 ```
 
-If the ping to `8.8.8.8` is successful, the message will be displayed. We can also display another message if there is no Internet connection. So let's add an `else` statement:
+If the ping to `8.8.8.8` is successful, the message will be displayed. We can also display another message if there is no internet connection. So let's add an `else` statement:
 
 ```sh
 if ping -c 1 -W 3 8.8.8.8
@@ -222,10 +222,10 @@ fi
 Checking if a variable exists:
 
 ```sh
-# This If statement will be executed
+# This If statement will be executed because var was not declared
 if [ -z "$var" ]
 then
-	echo "Variable "var" does not exist"
+	echo "Variable 'var' does not exist"
 fi
 ```
 
@@ -234,7 +234,7 @@ Checking if a file exists:
 ```sh
 if [ -f "file" ]
 then
-	echo The file with the name "file" does exist"
+	echo "The file with the name 'file' does exist"
 fi
 ```
 
@@ -265,18 +265,18 @@ echo "$first_var + $second_var = $result_addition"
 
 # Subtraction
 result_subtraction=$(($first_var - $second_var))
-echo "$first_var - $second_var = $result_addition"
+echo "$first_var - $second_var = $result_subtraction"
 
 # Multiplication
 result_multiplication=$(($first_var * $second_var))
-echo "$first_var * $second_var = $result_addition"
+echo "$first_var * $second_var = $result_multiplication"
 
 # Division
 result_division=$(($first_var / $second_var))
-echo "$first_var / $second_var = $result_addition"
+echo "$first_var / $second_var = $result_division"
 ```
 
-Please note that there are not floating point numbers in Bash. This means that the quotient of 3 and 4 (`$((3 / 4))`) is 0. Instead, a tool like `bc` is needed.
+Please note that there are no floating point numbers in Bash. This means that the quotient of 3 and 4 (`$((3 / 4))`) is 0. Instead, a tool like `bc` is needed.
 
 # While Loops
 
@@ -333,7 +333,7 @@ Then we can run it:
 $ /path/to/my-script
 ```
 
-If the script is our current working directory, it can be executed like this:
+If the script is in our current working directory, it can be executed like this:
 
 ```sh
 $ ./my-script
@@ -341,7 +341,7 @@ $ ./my-script
 
 # Conclusion
 
-In this tutorial, you've learned how to write basic POSIX compliant scripts including commands, comments, variables, If statements, While statements, maths and delays.
+In this tutorial, you've learned how to write basic POSIX compliant scripts including commands, comments, variables, If statements, While statements, basic mathematical operations and delays.
 
 # License
 


### PR DESCRIPTION
Fixed some typos and copy and paste script errors in the Basic Math section of the tutorial basic-scripting for all operations except addition.

The sample product URL https://www.netcup.de/bestellen/produkt.php?produkt=2000 does not exist but maybe some basic VPS product should be linked.