### PR TITLE
Fixed typo in tutorial debootstrap

### DIFF
--- a/community-tutorials/debootstrap/01-en.md
+++ b/community-tutorials/debootstrap/01-en.md
@@ -246,7 +246,7 @@ cp -a /etc/ssh/sshd_conf.d/* /mnt/debinst/etc/ssh/sshd_conf.d/
 
 This only works if you have already put your configuration into the `sshd_conf.d` directory. If it still resides in the `sshd_conf` file, you might either extract the information (recommended) or copy that file.
 
-To avoid problems with the host_key identification, we make a backup copy of the host keys that where generated when we installed SSH and copy the host keys from the old system to the new system.
+To avoid problems with the host_key identification, we make a backup copy of the host keys that were generated when we installed SSH and copy the host keys from the old system to the new system.
 
 ```bash
 # Install zip if it is not yet installed on your system


### PR DESCRIPTION
Fixed a typo where -> were in the debootstrap tutorial.