### PR TITLE
Fixed typo table in dockerized-csgo-gameserver tutorial

### DIFF
--- a/community-tutorials/dockerized-csgo-gameserver/01-en.md
+++ b/community-tutorials/dockerized-csgo-gameserver/01-en.md
@@ -112,7 +112,7 @@ game_mode 1
 sv_pure 1
 // host_workshop_collection <WORKSHOP COL ID>
 // workshop_start_map <WORKSHOP START MAP>
-map de_dust2          // set default map here if not using a workshop map
+map de_dust2                            // set default map here if not using a workshop map
 log on
 sv_allow_votes 0
 sv_logbans 1
@@ -127,9 +127,9 @@ sv_minupdaterate "128"
 sv_mincmdrate "128"
 sv_pure 1
 sv_pure_kick_clients 1
-hostname "My CSGO Server"           // change this to your servers name (optional)
-rcon_password ""    // change this if you want to enter commands from the cs:go client (optional)
-sv_password ""        // change this to protect the server with a password (optional)
+hostname "My CSGO Server"               // change this to your servers name (optional)
+rcon_password ""                        // change this if you want to enter commands from the cs:go client (optional)
+sv_password ""                          // change this to protect the server with a password (optional)
 sv_cheats 0
 sv_lan 0
 exec banned_user.cfg

--- a/community-tutorials/dockerized-csgo-gameserver/01-en.md
+++ b/community-tutorials/dockerized-csgo-gameserver/01-en.md
@@ -140,17 +140,79 @@ The `autoexec.cfg` file is executed when the server first starts, here you can d
 You can also set things like the workshop collection if you have some maps from the Steam workshop you want to play on.
 But most importantly, you have to add your GSLT key that you generated for your server [here](https://steamcommunity.com/dev/managegameservers). Insert the GSLT key after `sv_setsteamaccount` in the first line. You can connect to your server over the internet if this key is present.
 
-For all game modes and game types see this table:
-| game_type | | game_mode | | |
-|-----------|-------------|-------------|------------|----------------|
-| | 0 | 1 | 2 | 3 |
-| 0 | casual | competetive | wingman | weapons expert |
-| 1 | armsrace | demolition | deathmatch | |
-| 2 | training | | | |
-| 3 | custom | | | |
-| 4 | guardian | coop strike | | |
-| 5 | skirmish | | | |
-| 6 | danger zone | | | |
+For all game modes and game types see this table from the [Valve Developer Wiki - CS:GO Game Modes](https://developer.valvesoftware.com/wiki/CS:GO_Game_Modes)
+<table>
+<thead>
+  <tr>
+    <th colspan="2" rowspan="2">game_type</th>
+    <th colspan="4">game_mode</th>
+  </tr>
+  <tr>
+    <th>0</th>
+    <th>1</th>
+    <th>2</th>
+    <th>3</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>Classic</td>
+    <td>0</td>
+    <td>Casual</td>
+    <td>Competitive</td>
+    <td>Wingman</td>
+    <td>Weapons Expert</td>
+  </tr>
+  <tr>
+    <td>Gun Game</td>
+    <td>1</td>
+    <td>Arms Race</td>
+    <td>Demolition</td>
+    <td>Deathmatch</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Training</td>
+    <td>2</td>
+    <td>Training</td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Custom</td>
+    <td>3</td>
+    <td>Custom</td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Cooperative</td>
+    <td>4</td>
+    <td>Guardian</td>
+    <td>Co-op Strike</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Skirmish</td>
+    <td>5</td>
+    <td>War Games<br></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Free For All</td>
+    <td>6</td>
+    <td>Danger Zone</td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+</tbody>
+</table>
 
 Now create `config.cfg` with the following content:
 
@@ -335,7 +397,7 @@ Alternatively you sometimes might need access to the command line interface for 
 This can be done by attaching to the container by running:
 
 ```bash
-# this is essentially the same as opening your console in the CSGO client
+# this is essentially the same as opening your console in the CS:GO client
 docker attach csgo
 ```
 


### PR DESCRIPTION
Fixing typo and html table in dockerized-csgo-gameserver tutorial adding link to developer wiki plus aligned comments in autoexec.cfg for better readability.

To see the changed Markdown rendered for comparison use this link to the patch-7 branch:
https://github.com/Copro/community-tutorials/blob/patch-7/community-tutorials/dockerized-csgo-gameserver/01-en.md