### PR TITLE
Fixed typo formatting in squid tutorial

### DIFF
--- a/community-tutorials/squid/01-en.md
+++ b/community-tutorials/squid/01-en.md
@@ -36,7 +36,7 @@ apt install curl sudo wget apache2-utils nano -y
 apt install squid -y
 ```
 
-# Step 1.1 - Inserting the configuration
+## Step 1.1 - Inserting the configuration
 
 Now we need to insert a configuration to the Squid proxy. <br>
 This configuration allows you to connect to the HTTP proxy using a username and password and makes your origin IP invisible to the web servers you visit. <br>
@@ -92,7 +92,7 @@ The restart may take a longer while.
 - Activate the checkbox "Don't use the proxy server for local (intranet) addresses". <br>
 - Click the "Save" button.<br>
 
-You will sometimes be asked for one of the usernames (and related password) that we previously created in [Step 1.2](#step-1.2---creating-users).
+You will sometimes be asked for one of the usernames (and related password) that we previously created in [Step 1.2](#step-1.2-creating-users).
 
 ## Step 2.2 - Windows 10
 
@@ -102,7 +102,7 @@ You will sometimes be asked for one of the usernames (and related password) that
 - Activate the checkbox "Don't use the proxy server for local (intranet) addresses".<br>
 - Click the "Save" button.<br>
 
-You will sometimes be asked for one of the usernames (and related password) that we previously created in Step 1.2.
+You will sometimes be asked for one of the usernames (and related password) that we previously created in [Step 1.2](#step-1.2-creating-users).
 
 ## Step 2.3 - Android
 
@@ -112,14 +112,14 @@ You will sometimes be asked for one of the usernames (and related password) that
 - Under "Address" or "Hostname" enter the IP address or the hostname of your proxy server and under "Port" add port `3128`. <br>
 - Click the "Save" button. <br>
 
-You will sometimes be asked for one of the usernames (and related password) that we previously created in Step 1.2.
+You will sometimes be asked for one of the usernames (and related password) that we previously created in [Step 1.2](#step-1.2-creating-users).
 
 ## Step 2.4 - IOS - iPadOS
 
 - Open your "Settings" app and go to your Wi-Fi settings. <br>
 - Press your Wi-Fi network and select "Configure proxy", then select "Manual".<br>
 - Under "Server" enter the IP address or the hostname of your proxy server and under "Port" add port `3128`. <br>
-- Activate the "Authentication" checkbox and enter your username (and related password) that we previously created in Step 1.2. <br>
+- Activate the "Authentication" checkbox and enter your username (and related password) that we previously created in [Step 1.2](#step-1.2-creating-users). <br>
 - Now click the upper button to save.
 
 ## Step 2.5 - macOS
@@ -129,7 +129,7 @@ You will sometimes be asked for one of the usernames (and related password) that
 - Enter your IP address or the hostname of your proxy server and port `3128`. <br>
 - Click "Ok" and then "Apply". <br>
 
-Now if you are asked for it (you may need to reboot), enter your username (and related password) that we previously created in Step 1.2.
+Now if you are asked for it (you may need to reboot), enter your username (and related password) that we previously created in [Step 1.2](#step-1.2-creating-users).
 
 ## Step 2.6 - Linux
 
@@ -142,7 +142,7 @@ apt install curl sudo wget nano -y
 sudo nano /etc/environment
 ```
 
-Now add the following lines replacing `username` with an actual username and define a `password` for the user. This is one of the users we previously created in Step 1.2. Also, replace "hostname" with the IP address or the hostname of your proxy server and "port" with port `3128`:
+Now add the following lines replacing `username` with an actual username and define a `password` for the user. This is one of the users we previously created in [Step 1.2](#step-1.2-creating-users). Also, replace "hostname" with the IP address or the hostname of your proxy server and "port" with port `3128`:
 
 ```sh
 http_proxy="http://<username>:<password>@<hostname>:<port>/"

--- a/community-tutorials/squid/01-en.md
+++ b/community-tutorials/squid/01-en.md
@@ -38,7 +38,7 @@ apt install squid -y
 
 ## Step 1.1 - Inserting the configuration
 
-Now we need to insert a configuration to the Squid proxy. <br>
+Now we need to add a configuration to the Squid proxy. <br>
 This configuration allows you to connect to the HTTP proxy using a username and password and makes your origin IP invisible to the web servers you visit. <br>
 Open the configuration:
 
@@ -46,7 +46,7 @@ Open the configuration:
 nano /etc/squid/squid.conf
 ```
 
-Now add the following lines to the beginning of the file:
+Add the following lines to the beginning of the file:
 
 ```
 
@@ -62,15 +62,15 @@ Save your changes by pressing **CTRL + X**, then **Y** and finally by hitting **
 
 ## Step 1.2 - Creating users
 
-Now we need to create users to access the proxy. <br>
-In the following command, please replace "USERNAME" with the actual username you will use to log in to the proxy with a password.
+In this step we need to create users to access the proxy. <br>
+In the following command, please replace "USERNAME" with the actual username you will use for password login to the proxy:
 
 ```sh
 htpasswd -c /etc/squid/passwords USERNAME
 ```
 
 Now enter a new secure password. <br>
-Repeat this step depending on how many users you need to use this proxy.
+Repeat this step depending on the number of users you want to use this proxy.
 
 ## Step 1.3 - Starting Squid
 

--- a/community-tutorials/squid/01-en.md
+++ b/community-tutorials/squid/01-en.md
@@ -92,7 +92,7 @@ The restart may take a longer while.
 - Activate the checkbox "Don't use the proxy server for local (intranet) addresses". <br>
 - Click the "Save" button.<br>
 
-You will sometimes be asked for one of the usernames (and related password) that we previously created in Step 1.2.
+You will sometimes be asked for one of the usernames (and related password) that we previously created in [Step 1.2](#step-1.2---creating-users).
 
 ## Step 2.2 - Windows 10
 
@@ -150,7 +150,7 @@ https_proxy="http://<username>:<password>@<hostname>:<port>/"
 no_proxy="localhost,127.0.0.1,::1"
 ```
 
-Now save your changes by pressing **CTRL + X**, pressing **Y** and finally by hitting \*\*Enter".
+Now save your changes by pressing **CTRL + X**, pressing **Y** and finally by hitting **Enter**.
 
 # Conclusion
 

--- a/community-tutorials/squid/01-en.md
+++ b/community-tutorials/squid/01-en.md
@@ -92,7 +92,7 @@ The restart may take a longer while.
 - Activate the checkbox "Don't use the proxy server for local (intranet) addresses". <br>
 - Click the "Save" button.<br>
 
-You will sometimes be asked for one of the usernames (and related password) that we previously created in [Step 1.2](#step-1.2-creating-users).
+You will sometimes be asked for one of the usernames (and related password) that we previously created in [Step 1.2](#step-12---creating-users).
 
 ## Step 2.2 - Windows 10
 
@@ -102,7 +102,7 @@ You will sometimes be asked for one of the usernames (and related password) that
 - Activate the checkbox "Don't use the proxy server for local (intranet) addresses".<br>
 - Click the "Save" button.<br>
 
-You will sometimes be asked for one of the usernames (and related password) that we previously created in [Step 1.2](#step-1.2-creating-users).
+You will sometimes be asked for one of the usernames (and related password) that we previously created in [Step 1.2](#step-12---creating-users).
 
 ## Step 2.3 - Android
 
@@ -112,14 +112,14 @@ You will sometimes be asked for one of the usernames (and related password) that
 - Under "Address" or "Hostname" enter the IP address or the hostname of your proxy server and under "Port" add port `3128`. <br>
 - Click the "Save" button. <br>
 
-You will sometimes be asked for one of the usernames (and related password) that we previously created in [Step 1.2](#step-1.2-creating-users).
+You will sometimes be asked for one of the usernames (and related password) that we previously created in [Step 1.2](#step-12---creating-users).
 
 ## Step 2.4 - IOS - iPadOS
 
 - Open your "Settings" app and go to your Wi-Fi settings. <br>
 - Press your Wi-Fi network and select "Configure proxy", then select "Manual".<br>
 - Under "Server" enter the IP address or the hostname of your proxy server and under "Port" add port `3128`. <br>
-- Activate the "Authentication" checkbox and enter your username (and related password) that we previously created in [Step 1.2](#step-1.2-creating-users). <br>
+- Activate the "Authentication" checkbox and enter your username (and related password) that we previously created in [Step 1.2](#step-12---creating-users). <br>
 - Now click the upper button to save.
 
 ## Step 2.5 - macOS
@@ -129,7 +129,7 @@ You will sometimes be asked for one of the usernames (and related password) that
 - Enter your IP address or the hostname of your proxy server and port `3128`. <br>
 - Click "Ok" and then "Apply". <br>
 
-Now if you are asked for it (you may need to reboot), enter your username (and related password) that we previously created in [Step 1.2](#step-1.2-creating-users).
+Now if you are asked for it (you may need to reboot), enter your username (and related password) that we previously created in [Step 1.2](#step-12---creating-users).
 
 ## Step 2.6 - Linux
 
@@ -142,7 +142,7 @@ apt install curl sudo wget nano -y
 sudo nano /etc/environment
 ```
 
-Now add the following lines replacing `username` with an actual username and define a `password` for the user. This is one of the users we previously created in [Step 1.2](#step-1.2-creating-users). Also, replace "hostname" with the IP address or the hostname of your proxy server and "port" with port `3128`:
+Now add the following lines replacing `username` with an actual username and define a `password` for the user. This is one of the users we previously created in [Step 1.2](#step-12---creating-users). Also, replace "hostname" with the IP address or the hostname of your proxy server and "port" with port `3128`:
 
 ```sh
 http_proxy="http://<username>:<password>@<hostname>:<port>/"


### PR DESCRIPTION
Fix section 1.1 indent as subsection
Fix **ENTER** in last section
Change Step 1.2 to links with anchors to section header 1.2