### PR TITLE
Replaced kernel-doc-link to sphinx-formatted docs

### DIFF
--- a/community-tutorials/zram-tutorial/01-en.md
+++ b/community-tutorials/zram-tutorial/01-en.md
@@ -101,7 +101,7 @@ vm.dirty_background_ratio=1
 vm.dirty_ratio=50
 ```
 
-The configuration above works well on systems with low memory. We start swapping early (as we want to use our zRam as early as possible) and have set a high cache pressure to reduce memory consumption in the long run. For a full explanation of the settings take a look here: [https://www.kernel.org/doc/Documentation/sysctl/vm.txt](https://www.kernel.org/doc/Documentation/sysctl/vm.txt)
+The configuration above works well on systems with low memory. We start swapping early (as we want to use our zRam as early as possible) and have set a high cache pressure to reduce memory consumption in the long run. For a full explanation of the settings take a look here: [https://www.kernel.org/doc/html/latest/admin-guide/sysctl/vm.html](https://www.kernel.org/doc/html/latest/admin-guide/sysctl/vm.html)
 
 # License
 


### PR DESCRIPTION
The prior link (https://www.kernel.org/doc/Documentation/sysctl/vm.txt)
references kernel version 2.6.29 without providing context on whether
it's up-to-date and applicable for the latest kernel version.
![grafik](https://user-images.githubusercontent.com/8365178/165946122-609f3fcf-f0ee-451e-867d-2020fbe5eb85.png)
vs. 
![grafik](https://user-images.githubusercontent.com/8365178/165946017-6e9c5b0a-f147-473f-a149-9647c17d792c.png)
