### PR TITLE
Fixed typo in tutorial how-to-install-postgres-and-pgadmin

### DIFF
--- a/community-tutorials/how-to-install-postgres-and-pgadmin-with-docker-and-connect-pgadmin-with-postgres/01-en.md
+++ b/community-tutorials/how-to-install-postgres-and-pgadmin-with-docker-and-connect-pgadmin-with-postgres/01-en.md
@@ -17,7 +17,8 @@ available_languages: en
 This tutorial explains how to install the PostgreSQL database and its pgAdmin tool on a virtual server with Docker and how to connect pgAdmin to PostgreSQL. pgAdmin is a web-based administration tool for the PostgreSQL database.
 
 # Requirements
-You need a virtual server from netcup with Debian or Ubuntu installed. This tutorial also requires the setup of Docker and Docker Compose. On the netcup Community Tutorials site, you can find a tutorial that describes how to set up Docker and Docker Compose on Ubuntu.
+You need a virtual server from netcup with Debian or Ubuntu installed. This tutorial also requires the setup of Docker and Docker Compose.
+Refer to the netcup community tutorial [install-docker](https://github.com/netcup-community/community-tutorials/blob/main/community-tutorials/install-docker/01-en.md) for instructions on how to set up Docker and Docker Compose on Ubuntu.
 
 # Step 1 - Check your Docker and Docker Compose versions
 Check the Docker version:

--- a/community-tutorials/how-to-install-postgres-and-pgadmin-with-docker-and-connect-pgadmin-with-postgres/01-en.md
+++ b/community-tutorials/how-to-install-postgres-and-pgadmin-with-docker-and-connect-pgadmin-with-postgres/01-en.md
@@ -157,7 +157,7 @@ The server connection opens automatically and the first page displays live stati
 
 # Step 7 - Stop and remove all services
 If you don't need the PostgreSQL database and pgAdmin anymore, you can stop and remove the two services with one command:
-Run in the command-line:
+Run in the command line:
 ```
 docker-compose down
 ```


### PR DESCRIPTION
Fix typo in folder of tutorial how-to-install-postgres-and-pgadmin-with-docker-and-connect-pgadmin-with-postgres and link to docker and docker-compose tutorial.