### PR TITLE
Update English instructions on Rouncube install

### DIFF
--- a/community-tutorials/install-roundcube/01-en.md
+++ b/community-tutorials/install-roundcube/01-en.md
@@ -96,7 +96,7 @@ You may replace any settings depending on your needs, but at minimum you will ha
 - smtp_server
 
 
-The following is a full sample configuration that could be used after replacing the document roots in db_dsnw, mime_types and filling a new 24 character long des_key:
+The following is a full sample configuration that could be used after replacing the document roots in db_dsnw, mime_types and filling a new 24 character long des_key: (the command `openssl rand -hex 12` can be used on a machine with openssl to create a unique des_key directly)
 ```
 <?php
 
@@ -170,6 +170,29 @@ $config['enable_spellcheck'] = true;
 
 // in case you want to use the installer again uncomment this
 $config['enable_installer'] = true;
+
+```
+
+
+To correctly use the managesieve plugin, we need to create one more configuration.
+
+Copy the managesieve plugin sample configuration file:
+`cp plugins/managesieve/config.inc.php.dist plugins/managesieve/config.inc.php`
+
+Configure the managesieve plugin by editing the config.inc.php file using your favorite editor. We will be using nano.
+`nano plugins/managesieve/config.inc.php`
+
+```
+// managesieve server port. When empty the port will be determined automatically
+// using getservbyname() function, with 4190 as a fallback.
+$config['managesieve_port'] = '';
+
+// managesieve server address, default is localhost but we use the IMAP hostname, which is variable %h
+// %h - user's IMAP hostname
+$config['managesieve_host'] = '%h';
+
+// use TLS for managesieve server connection, because we did not use the tls:// prefix in managesieve_host
+$config['managesieve_usetls'] = true;
 
 ```
 


### PR DESCRIPTION
Update English instructions on Rouncube install adding note to use openssl to create unique 24 digits des_key plus correctly configure the managesieve plugin for the netcup default webhosting imap host.