### PR TITLE
Tutorial: Setup and Basic Configuration of Caddy Webserver

### DIFF
--- a/community-tutorials/setup-caddy-server/01-en.md
+++ b/community-tutorials/setup-caddy-server/01-en.md
@@ -1,26 +1,28 @@
+
+
 ---
-title: Setup of Caddy Server - The easiest way to provide secure HTTPS connections
-description: Caddy is a web server that is very easy to setup and maintain. It uses Let's Encrypt certificates almost without configuration or additional programs!
-level: [ beginner ]
+title: Caddy Server Setup - The easiest way to provide secure HTTPS connections
+description: Caddy is a web server that is very easy to set up and maintain. It uses Let's Encrypt certificates almost without configuration or additional programs!
+level: beginner
 updated_at: 2023-09-29
 slug: setup-caddy
 author_name: Anton Mrosek
 author_url: https://github.com/anjomro/
 author_image: https://avatars.githubusercontent.com/u/17234179?v=4
 author_bio:
-tags: [ shell, ssh, linux, caddy, webserver, https, tls, reverse-proxy]
+tags: [shell, ssh, linux, caddy, webserver, https, tls, reverse-proxy]
 netcup_product_url: https://www.netcup.de/bestellen/produkt.php?produkt=2948
 language: en
-available_languages: [ de, en ]
+available_languages: [de, en]
 ---
 
 # Introduction
 
-This tutorial explains how to setup the caddy web server. Additionally, it shows how to serve static files using caddy
-as well as how to run a reverse proxy, that e.g. exposes services running on docker to the outside world.
+This tutorial explains how to install and configure the Caddy web server. It also shows how to deploy static files using Caddy
+and how to run a reverse proxy that, for example, exposes services running on Docker to the outside world.
 
-Caddy is easy to use and configure, due to its configuration file format. A simple configration file for a reverse proxy
-featuring automatic HTTPS can look like this:
+Due to its configuration file format, Caddy is easy to use and configure. A simple configuration file for a reverse proxy
+featuring automatic HTTPS might look like this:
 
 ```
 my-cool-domain.de {
@@ -30,10 +32,10 @@ my-cool-domain.de {
 }
 ```
 
-We'll go into detail about the caddy server configuration later on.
+We'll go into detail about the Caddy server configuration later.
 
 <details>
-<summary>An equivalent nginx server config might look like this and require additional tools like certbot:</summary>
+<summary>An equivalent nginx server config might look like this and it requires additional tools like Certbot:</summary>
 
 ```
 server {
@@ -67,7 +69,7 @@ server {
 </details>
 
 <details>
-<summary>An equivalent apache2 server config might look like this and would require a tool like certbot as well:</summary>
+<summary>An equivalent Apache2 server config might look like this and would require a tool like Certbot as well:</summary>
 
 ```
 <VirtualHost *:80>
@@ -95,51 +97,50 @@ server {
 </details>
 
 
-As you can see the caddy configuration is much simpler and easier to understand. Caddy also takes care of obtaining and
-using the Let's Encrypt certificate without any configuration!
+By comparison, the Caddy configuration is much simpler and easier to understand. Caddy also takes care of obtaining and
+using a Let's Encrypt certificate without any configuration!
 
-So let's get started on how to setup caddy on your own server.
+So let's get started on how to set up Caddy on your own server.
 
 # Requirements
 
-For following this tutorial you need the following:
+For this tutorial you need the following:
 
-- A server (e.g. VPS) running a recent Version of Ubuntu and access over SSH
-    - The server needs a public ipv4 or ipv6 address. Netcup VPS / RS server always have ipv4 and ipv6 addresses.
-    - The tutorial might be applicable to other linux distributions, only the actual installation of caddy might differ.
+- A server (e.g. VPS) running a recent version of Ubuntu with access via SSH
+    - The server needs a public ipv4 or ipv6 address. netcup VPS / RS servers always have ipv4 and ipv6 addresses.
+    - The tutorial might also be applicable to other Linux distributions, especially the `Caddyfile` part.
+    - This tutorial was tested with Ubuntu 22.04.
 - A domain name or a subdomain where you have control over the DNS settings
-- Optional: If you want to create a reverse proxy using caddy you need a service running on your server that you want to
-  expose to
-  the outside world.
+- Optional: If you want to create a reverse proxy using Caddy, you need a service running on your server that you want to
+  expose to the outside world.
 
-For this tutorial we will use the domain `my-cool-domain.de` as an example. You can replace it with your own domain name
-or subdomain.
+For this tutorial we will use the domain `my-cool-domain.de` as an example. If necessary, you should replace this with your own domain name
+or subdomain, e.g. in the configuration examples.
 
-# Step 1 - Setting up the DNS records
+# Step 1 - Setting up the DNS records 
 
-For using your domain with your server it is necessary to set up the DNS records to point to teh public ipv4 and/or ipv6
-address of your server. If both are set the client will choose whether to connect via ipv4 or ipv6.
+For using your domain with your server, you must set up the DNS records to properly point to the public ipv4 and/or ipv6
+address of your server. If both are set, the client will choose whether to connect via ipv4 or ipv6.
 
-## Step 1.1 - Getting the IP Adresses of your server
+## Step 1.1 - Getting the IP addresses of your server
 
-First we need to get the public ipv4 and ipv6 addresses of your server. This can be done using the following commands
-that you can run on your server:
+First, we need to find out the public ipv4 and ipv6 addresses of your server. You can do this with the following command:
 
 ```bash
 echo -n -e "\n\nipv4 address:  " && curl -4 ifconfig.co
 echo -n -e "\nipv6 address:  " && curl -6 ifconfig.co
 ```
 
-Note down your servers ipv4 and ipv6 address. We will need them in the next step.
+Keep a note of your server's ipv4 and ipv6 addresses. We will need them in the next step.
 
-If you're seeing something like: `ipv6 address:  curl: (7) Couldn't connect to server` then your server might not have
-an ipv6 address. In that case you can use the ipv4 address only, it will work just fine.
+If you're seeing something like: `ipv6 address:  curl: (7) Couldn't connect to server`, then your server might not have
+an ipv6 address. In this case you can use the ipv4 address only, and it will just work fine.
 
 ## Step 1.2 - Setting up the DNS records
 
-The DNS records can be changed your DNS provider. If you haven't changed the default settings this most likely is the
+Your DNS records can be changed by your DNS provider. If you haven't changed the default settings, this is most likely the
 place where you bought your domain.
-If you purchased your domain at Netcup you can change the DNS records in the Customer Control Panel. There you need to
+If you purchased your domain at netcup, you can change the DNS records in the Customer Control Panel. There you need to
 select `Domains` > `my-cool-domain.de` > `DNS`.
 
 Then add the following entries to the DNS records:
@@ -149,26 +150,26 @@ Then add the following entries to the DNS records:
 | A    | @    | ipv4 address of your server |
 | AAAA | @    | ipv6 address of your server |
 
-If you don't have ipv4 or ipv6 you can omit the corresponding entry.
+If you're missing either ipv4 or ipv6, you can omit the corresponding entry.
 
 ## Step 1.3 - Checking the DNS records
 
-It can take up to 24 hours for the DNS records to be updated. However, it usually takes only a few minutes. You can
-check if the DNS records are updated using the following command:
+In principle, it can take up to 24 hours for the DNS records to be updated. However, it usually takes only a few minutes. To check
+whether the DNS records have been updated, use the following command:
 
 ```bash
 dig +short my-cool-domain.de
 ```
 
-If you see the ipv4 and/or ipv6 address of your server the DNS records are updated and you can continue with the next
+If you see the ipv4 and/or ipv6 address of your server, the DNS records have been updated and you can continue with the next
 step.
 
-# Step 2 - Installing caddy
+# Step 2 - Installing Caddy
 
-## Step 2.1 - Adding the caddy repository
+## Step 2.1 - Adding the Caddy repository
 
-Caddy is not available in the default Ubuntu repositories. Therefore we need to add the caddy repository first. This can
-be done using the following steps:
+As Caddy is not available in the default Ubuntu repositories, we'll start by adding the Caddy repository. To do so,
+carry out the following steps:
 
 - Download and install the repository signing key, so that the packages can be verified:
     - Enter your password when prompted (applies also to the following commands)
@@ -177,7 +178,7 @@ be done using the following steps:
 curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo tee /usr/share/keyrings/caddy.asc
 ```
 
-- Setup the repository:
+- Set up the repository:
 
 ```bash
 echo "deb [signed-by=/usr/share/keyrings/caddy.asc] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main" | sudo tee -a /etc/apt/sources.list.d/caddy-stable.list
@@ -189,23 +190,23 @@ echo "deb [signed-by=/usr/share/keyrings/caddy.asc] https://dl.cloudsmith.io/pub
 sudo apt update
 ```
 
-## Step 2.2 - Installing caddy
+## Step 2.2 - Installing Caddy
 
-Now that the repository is added we can install caddy using the following command:
+Now that the repository has been added, we can install Caddy with the following command:
 
 ```bash
 sudo apt install caddy
 ```
 
-Congratulations! You have successfully installed caddy on your server!
+Congratulations! You have successfully installed Caddy on your server!
 
-# Step 3 - Configuring caddy
+# Step 3 - Configuring Caddy
 
-The configuration file of caddy, the `Caddyfile`, is located at `/etc/caddy/Caddyfile`.
+The configuration file of Caddy, the `Caddyfile`, is located at `/etc/caddy/Caddyfile`.
 
-## Step 3.1 - Checking the default configuration and emptying the `Caddyfile`
+## Step 3.1 - Checking the default configuration and emptying `Caddyfile`
 
-You can have a look at it using the following command:
+To view the file, use the following command:
 
 ```bash
 sudo cat /etc/caddy/Caddyfile
@@ -246,15 +247,15 @@ sudo cat /etc/caddy/Caddyfile
 
 </details>
 
-For configuring caddy it will be the easiest to start with a blank `Caddyfile` and add the configuration step by step.
+To configure Caddy, the easiest way is to start with a blank `Caddyfile` and add the configuration step by step.
 
-To delete the default contents of the `Caddyfile` you can use the following command:
+To delete the default contents of the `Caddyfile`, use the following command:
 
 ```bash
 sudo truncate -s 0 /etc/caddy/Caddyfile
 ```
 
-You can verify that the `Caddyfile` is indeed empty by checking the contents again, if you like:
+If you wish, you can verify that the `Caddyfile` is indeed empty by checking the contents again:
 
 ```bash
 sudo cat /etc/caddy/Caddyfile
@@ -262,32 +263,36 @@ sudo cat /etc/caddy/Caddyfile
 
 ## Step 3.2 - Adding the first configuration
 
-Now we can add our first configuration to the `Caddyfile`. We will start with a simple configuration that serves the
+Now we can add our first configuration to the `Caddyfile`. We will start with a simple configuration to display the
 static html page that came with the caddy installation.
 
-To open and edit the `Caddyfile` you can use the following command:
+To open and edit the `Caddyfile`, use the following command:
 
 ```bash
 sudo nano /etc/caddy/Caddyfile
 ```
 
-To save the file you can press `CTRL + S` and to exit the editor you can press `CTRL + X`. Make sure to always save your
+To save the file, press `CTRL + S`. To exit the editor, press `CTRL + X`. Make sure to always save your
 changes.
 
-For the following steps only parts of the `Caddyfile` will be shown. You can simply copy these parts and paste them
-underneith the existing content of the `Caddyfile`. However you must make sure that only one entry is present for one
-name (e.g. `my-cool-domain.de`), that is important for domains as well as subdomains. If you have multiple entries for a
-name caddy will fail to start since it won't know which entry to use for the name.
+In the following steps only parts of the `Caddyfile` will be shown. Different configurations can in principle
+simply be placed one below the other. However, you have to make sure that there is only one entry for one
+name (e.g. `my-cool-domain.de`). This is important for domains as well as subdomains! If you have multiple entries for a
+name, Caddy will fail to start because it is not clear which entry should be used for the name.
 
-### Step 3.2.1 - Your first entry: Serving static html files
+### Step 3.2.1 - Your first entry: deploying static html files
 
-The first entry will serve static html files. For this we will use the `file_server` directive. The `file_server` will
-serve files from the directory specified in the `root` directive. The `root` directive must be specified before the
+The first entry will deploy static html files. For this, we will use the `file_server` directive. 
+
+#### Note: If you've set up a firewall you need to allow incoming connections on port 80 and 443 for Caddy to work.
+
+For example, you can add the following lines to the `Caddyfile`. 
+
+The `file_server` will deploy files from the directory specified in the `root` directive. The `root` directive must be specified before the
 `file_server` directive.
 
-#### Note: If you've set up a firewall you need to allow incoming connections on port 80 and 443 for caddy to work.
 
-For example, you can add the following lines to the `Caddyfile`. Remember to replace `my-cool-domain.de` with your own
+Remember to replace `my-cool-domain.de` with your own
 domain or subdomain where you configured the DNS records in step 1.2.
 
 ```
@@ -302,35 +307,35 @@ my-cool-domain.de {
 
 ```
 
-To activate your changes you need to let caddy reload the configuration using the following command:
+To activate your changes, you need to let Caddy reload the configuration using the following command:
 
 ```bash
 sudo systemctl reload caddy
 ```
 
-To see if caddy is running and for seeing some debugging output, e.g. if there is an error in your `Caddyfile` you can use the following command:
+To check if Caddy is running and for viewing some debugging output, e.g. if there is an error in your `Caddyfile`, use the following command:
 
 ```bash
 sudo systemctl status caddy
 ```
 
 
-Now you can open your domain in your browser and you should see the default caddy page at your domain/subdomain.
-Just enter https://my-cool-domain.de in your browser and you should see the default caddy page.
-If that doesn't work right away wait a minute, since caddy needs to request and setup the tls certificate.
-If you pay close attention and depending on the browser you'll see a padlock icon in the address bar, indicating that
-the connection is encrypted using https. In the background caddy has requested a tls certificate from Let's Encrypt
+Now you can open your domain in your browser and you should see the default Caddy page at your domain/subdomain.
+Just enter https://my-cool-domain.de in your browser and you should see the default Caddy page.
+If this doesn't work right away, wait a minute because Caddy needs to request and set up the TLS certificate.
+If you pay close attention and depending on the browser, you'll see a padlock icon in the address bar indicating that
+the connection is encrypted using https. In the background Caddy has requested a TLS certificate from Let's Encrypt
 and configured it for your domain.
 
-### Step 3.2.2 - Optional: Caddy as a reverse proxy
+### Step 3.2.2 - Optional: Using Caddy as a reverse proxy
 
-If you have a service running on your server that you want to expose to the outside world you can use caddy as a reverse
+If you have a service running on your server that you want to expose to the outside world, you can use Caddy as a reverse
 proxy.
 
-For this purpose you can use the `reverse_proxy` directive. The `reverse_proxy` directive will forward all requests to
+For this purpose, you can use the `reverse_proxy` directive. The `reverse_proxy` directive will forward all requests to
 the specified address.
 
-If you have a webservice running on port 8080 on your server you can use the following configuration to expose it to the
+If you have a webservice running on port 8080 on your server, you can use the following configuration to expose it to the
 outside world:
 
 ```
@@ -341,9 +346,9 @@ my-cool-domain.de {
 }
 ```
 
-Make sure that you don't have any other entries for `my-cool-domain.de` in your `Caddyfile` or caddy will fail to start.
+Make sure that you don't have any other entries for `my-cool-domain.de` in your `Caddyfile` or Caddy will fail to start.
 
-To activate your changes you need to let caddy reload the configuration using the following command:
+To activate your changes, you need to let Caddy reload the configuration using the following command:
 
 ```bash
 sudo systemctl reload caddy
@@ -351,17 +356,19 @@ sudo systemctl reload caddy
 
 # Conclusion
 
-We've now seen how to set up the server with two basic configurations. However, there are many more options available
-with caddy, also the shown configurations can be extended.
+In this tutorial you've learned how to set up the server with two basic configurations. However, with Caddy many other options are available,
+and even the configurations shown can be extended.
 
-These informations are available in the [caddy documentation](https://caddyserver.com/docs/caddyfile).
+This information is available in the [caddy documentation](https://caddyserver.com/docs/caddyfile).
 
-You can try out other directives you can find there in the same way we've done it in this tutorial. Just add them to the `Caddyfile` and reload caddy using `sudo systemctl reload caddy`.
+If you like, you can try out other directives from the documentation, just as we tried out the other configurations in this tutorial. 
 
-I find working with caddy and the `Caddyfile` very easy and intuitive. I hope you do too!
+Just add the directives to the `Caddyfile` and reload Caddy with `sudo systemctl reload caddy`.
+
+I find working with Caddy and the `Caddyfile` very easy and intuitive. I hope you feel the same way!
 
 
-# Licence
+# License
 
 [MIT](https://github.com/netcup-community/community-tutorials/blob/main/LICENSE)
 
@@ -382,12 +389,12 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 
 By making a contribution to this project, I certify that:
 
-1) The contribution was created in whole or in part by me and I have the right to submit it under the licence indicated
+1) The contribution was created in whole or in part by me and I have the right to submit it under the license indicated
    in the file; or
 
 2) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate
-   licence and I have the right under that licence to submit that work with modifications, whether created in whole or
-   in part by me, under the same licence (unless I am permitted to submit under a different licence), as indicated in
+   license and I have the right under that license to submit that work with modifications, whether created in whole or
+   in part by me, under the same license (unless I am permitted to submit under a different license), as indicated in
    the file; or
 
 3) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not
@@ -395,4 +402,5 @@ By making a contribution to this project, I certify that:
 
 4) I understand and agree that this project and the contribution are public and that a record of the contribution (
    including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be
-   redistributed consistent with this project or the licence(s) involved.
+   redistributed consistent with this project or the license(s) involved.
+

--- a/community-tutorials/setup-caddy-server/01-en.md
+++ b/community-tutorials/setup-caddy-server/01-en.md
@@ -1,6 +1,6 @@
 ---
 title: Setup of Caddy Server - The easiest way to provide secure HTTPS connections
-description: Caddy is a web server that is very easy to setup and maintain. It uses Let's Encrypt certificates almost without configuration!
+description: Caddy is a web server that is very easy to setup and maintain. It uses Let's Encrypt certificates almost without configuration or additional programs!
 level: [ beginner ]
 updated_at: 2023-09-29
 slug: setup-caddy
@@ -168,7 +168,7 @@ step.
 ## Step 2.1 - Adding the caddy repository
 
 Caddy is not available in the default Ubuntu repositories. Therefore we need to add the caddy repository first. This can
-be done using the following commands:
+be done using the following steps:
 
 - Download and install the repository signing key, so that the packages can be verified:
     - Enter your password when prompted (applies also to the following commands)

--- a/community-tutorials/setup-caddy-server/01-en.md
+++ b/community-tutorials/setup-caddy-server/01-en.md
@@ -1,5 +1,3 @@
-
-
 ---
 title: Caddy Server Setup - The easiest way to provide secure HTTPS connections
 description: Caddy is a web server that is very easy to set up and maintain. It uses Let's Encrypt certificates almost without configuration or additional programs!

--- a/community-tutorials/setup-caddy-server/01-en.md
+++ b/community-tutorials/setup-caddy-server/01-en.md
@@ -1,0 +1,398 @@
+---
+title: Setup of Caddy Server - The easiest way to provide secure HTTPS connections
+description: Caddy is a web server that is very easy to setup and maintain. It uses Let's Encrypt certificates almost without configuration!
+level: [ beginner ]
+updated_at: 2023-09-29
+slug: setup-caddy
+author_name: Anton Mrosek
+author_url: https://github.com/anjomro/
+author_image: https://avatars.githubusercontent.com/u/17234179?v=4
+author_bio:
+tags: [ shell, ssh, linux, caddy, webserver, https, tls, reverse-proxy]
+netcup_product_url: https://www.netcup.de/bestellen/produkt.php?produkt=2948
+language: en
+available_languages: [ de, en ]
+---
+
+# Introduction
+
+This tutorial explains how to setup the caddy web server. Additionally, it shows how to serve static files using caddy
+as well as how to run a reverse proxy, that e.g. exposes services running on docker to the outside world.
+
+Caddy is easy to use and configure, due to its configuration file format. A simple configration file for a reverse proxy
+featuring automatic HTTPS can look like this:
+
+```
+my-cool-domain.de {
+
+   reverse_proxy localhost:8080
+
+}
+```
+
+We'll go into detail about the caddy server configuration later on.
+
+<details>
+<summary>An equivalent nginx server config might look like this and require additional tools like certbot:</summary>
+
+```
+server {
+    listen 80;
+    server_name my-cool-domain.de www.my-cool-domain.de;
+
+    location / {
+        proxy_pass http://localhost:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ~ /.well-known/acme-challenge {
+        allow all;
+    }
+
+    location = /.well-known/acme-challenge/ {
+        return 404;
+    }
+
+    listen [::]:443 ssl ipv6only=on;
+    listen 443 ssl;
+    ssl_certificate /etc/letsencrypt/live/my-cool-domain.de/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/my-cool-domain.de/privkey.pem;
+}
+
+```
+
+</details>
+
+<details>
+<summary>An equivalent apache2 server config might look like this and would require a tool like certbot as well:</summary>
+
+```
+<VirtualHost *:80>
+    ServerName my-cool-domain.de
+    ServerAlias www.my-cool-domain.de
+
+    ProxyPass / http://localhost:8080/
+    ProxyPassReverse / http://localhost:8080/
+
+    DocumentRoot /var/www/html
+
+    <Directory /var/www/html>
+        Options FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    Alias /.well-known/acme-challenge/ /var/www/html/.well-known/acme-challenge/
+
+</VirtualHost>
+
+
+```
+
+</details>
+
+
+As you can see the caddy configuration is much simpler and easier to understand. Caddy also takes care of obtaining and
+using the Let's Encrypt certificate without any configuration!
+
+So let's get started on how to setup caddy on your own server.
+
+# Requirements
+
+For following this tutorial you need the following:
+
+- A server (e.g. VPS) running a recent Version of Ubuntu and access over SSH
+    - The server needs a public ipv4 or ipv6 address. Netcup VPS / RS server always have ipv4 and ipv6 addresses.
+    - The tutorial might be applicable to other linux distributions, only the actual installation of caddy might differ.
+- A domain name or a subdomain where you have control over the DNS settings
+- Optional: If you want to create a reverse proxy using caddy you need a service running on your server that you want to
+  expose to
+  the outside world.
+
+For this tutorial we will use the domain `my-cool-domain.de` as an example. You can replace it with your own domain name
+or subdomain.
+
+# Step 1 - Setting up the DNS records
+
+For using your domain with your server it is necessary to set up the DNS records to point to teh public ipv4 and/or ipv6
+address of your server. If both are set the client will choose whether to connect via ipv4 or ipv6.
+
+## Step 1.1 - Getting the IP Adresses of your server
+
+First we need to get the public ipv4 and ipv6 addresses of your server. This can be done using the following commands
+that you can run on your server:
+
+```bash
+echo -n -e "\n\nipv4 address:  " && curl -4 ifconfig.co
+echo -n -e "\nipv6 address:  " && curl -6 ifconfig.co
+```
+
+Note down your servers ipv4 and ipv6 address. We will need them in the next step.
+
+If you're seeing something like: `ipv6 address:  curl: (7) Couldn't connect to server` then your server might not have
+an ipv6 address. In that case you can use the ipv4 address only, it will work just fine.
+
+## Step 1.2 - Setting up the DNS records
+
+The DNS records can be changed your DNS provider. If you haven't changed the default settings this most likely is the
+place where you bought your domain.
+If you purchased your domain at Netcup you can change the DNS records in the Customer Control Panel. There you need to
+select `Domains` > `my-cool-domain.de` > `DNS`.
+
+Then add the following entries to the DNS records:
+
+| Type | Host | Value                       |
+|------|------|-----------------------------|
+| A    | @    | ipv4 address of your server |
+| AAAA | @    | ipv6 address of your server |
+
+If you don't have ipv4 or ipv6 you can omit the corresponding entry.
+
+## Step 1.3 - Checking the DNS records
+
+It can take up to 24 hours for the DNS records to be updated. However, it usually takes only a few minutes. You can
+check if the DNS records are updated using the following command:
+
+```bash
+dig +short my-cool-domain.de
+```
+
+If you see the ipv4 and/or ipv6 address of your server the DNS records are updated and you can continue with the next
+step.
+
+# Step 2 - Installing caddy
+
+## Step 2.1 - Adding the caddy repository
+
+Caddy is not available in the default Ubuntu repositories. Therefore we need to add the caddy repository first. This can
+be done using the following commands:
+
+- Download and install the repository signing key, so that the packages can be verified:
+    - Enter your password when prompted (applies also to the following commands)
+
+```bash
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo tee /usr/share/keyrings/caddy.asc
+```
+
+- Setup the repository:
+
+```bash
+echo "deb [signed-by=/usr/share/keyrings/caddy.asc] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main" | sudo tee -a /etc/apt/sources.list.d/caddy-stable.list
+```
+
+- Update the package cache, so that the packages from the new repository are available:
+
+```bash
+sudo apt update
+```
+
+## Step 2.2 - Installing caddy
+
+Now that the repository is added we can install caddy using the following command:
+
+```bash
+sudo apt install caddy
+```
+
+Congratulations! You have successfully installed caddy on your server!
+
+# Step 3 - Configuring caddy
+
+The configuration file of caddy, the `Caddyfile`, is located at `/etc/caddy/Caddyfile`.
+
+## Step 3.1 - Checking the default configuration and emptying the `Caddyfile`
+
+You can have a look at it using the following command:
+
+```bash
+sudo cat /etc/caddy/Caddyfile
+```
+
+<details>
+<summary>Your Caddyfile should look similar to this:</summary>
+
+```
+# The Caddyfile is an easy way to configure your Caddy web server.
+#
+# Unless the file starts with a global options block, the first
+# uncommented line is always the address of your site.
+#
+# To use your own domain name (with automatic HTTPS), first make
+# sure your domain's A/AAAA DNS records are properly pointed to
+# this machine's public IP, then replace ":80" below with your
+# domain name.
+
+:80 {
+        # Set this path to your site's directory.
+        root * /usr/share/caddy
+
+        # Enable the static file server.
+        file_server
+
+        # Another common task is to set up a reverse proxy:
+        # reverse_proxy localhost:8080
+
+        # Or serve a PHP site through php-fpm:
+        # php_fastcgi localhost:9000
+}
+
+# Refer to the Caddy docs for more information:
+# https://caddyserver.com/docs/caddyfile
+
+```
+
+</details>
+
+For configuring caddy it will be the easiest to start with a blank `Caddyfile` and add the configuration step by step.
+
+To delete the default contents of the `Caddyfile` you can use the following command:
+
+```bash
+sudo truncate -s 0 /etc/caddy/Caddyfile
+```
+
+You can verify that the `Caddyfile` is indeed empty by checking the contents again, if you like:
+
+```bash
+sudo cat /etc/caddy/Caddyfile
+```
+
+## Step 3.2 - Adding the first configuration
+
+Now we can add our first configuration to the `Caddyfile`. We will start with a simple configuration that serves the
+static html page that came with the caddy installation.
+
+To open and edit the `Caddyfile` you can use the following command:
+
+```bash
+sudo nano /etc/caddy/Caddyfile
+```
+
+To save the file you can press `CTRL + S` and to exit the editor you can press `CTRL + X`. Make sure to always save your
+changes.
+
+For the following steps only parts of the `Caddyfile` will be shown. You can simply copy these parts and paste them
+underneith the existing content of the `Caddyfile`. However you must make sure that only one entry is present for one
+name (e.g. `my-cool-domain.de`), that is important for domains as well as subdomains. If you have multiple entries for a
+name caddy will fail to start since it won't know which entry to use for the name.
+
+### Step 3.2.1 - Your first entry: Serving static html files
+
+The first entry will serve static html files. For this we will use the `file_server` directive. The `file_server` will
+serve files from the directory specified in the `root` directive. The `root` directive must be specified before the
+`file_server` directive.
+
+#### Note: If you've set up a firewall you need to allow incoming connections on port 80 and 443 for caddy to work.
+
+For example, you can add the following lines to the `Caddyfile`. Remember to replace `my-cool-domain.de` with your own
+domain or subdomain where you configured the DNS records in step 1.2.
+
+```
+
+my-cool-domain.de {
+
+   root * /usr/share/caddy
+
+   file_server
+
+}
+
+```
+
+To activate your changes you need to let caddy reload the configuration using the following command:
+
+```bash
+sudo systemctl reload caddy
+```
+
+To see if caddy is running and for seeing some debugging output, e.g. if there is an error in your `Caddyfile` you can use the following command:
+
+```bash
+sudo systemctl status caddy
+```
+
+
+Now you can open your domain in your browser and you should see the default caddy page at your domain/subdomain.
+Just enter https://my-cool-domain.de in your browser and you should see the default caddy page.
+If that doesn't work right away wait a minute, since caddy needs to request and setup the tls certificate.
+If you pay close attention and depending on the browser you'll see a padlock icon in the address bar, indicating that
+the connection is encrypted using https. In the background caddy has requested a tls certificate from Let's Encrypt
+and configured it for your domain.
+
+### Step 3.2.2 - Optional: Caddy as a reverse proxy
+
+If you have a service running on your server that you want to expose to the outside world you can use caddy as a reverse
+proxy.
+
+For this purpose you can use the `reverse_proxy` directive. The `reverse_proxy` directive will forward all requests to
+the specified address.
+
+If you have a webservice running on port 8080 on your server you can use the following configuration to expose it to the
+outside world:
+
+```
+my-cool-domain.de {
+
+   reverse_proxy localhost:8080
+
+}
+```
+
+Make sure that you don't have any other entries for `my-cool-domain.de` in your `Caddyfile` or caddy will fail to start.
+
+To activate your changes you need to let caddy reload the configuration using the following command:
+
+```bash
+sudo systemctl reload caddy
+```
+
+# Conclusion
+
+We've now seen how to set up the server with two basic configurations. However, there are many more options available
+with caddy, also the shown configurations can be extended.
+
+These informations are available in the [caddy documentation](https://caddyserver.com/docs/caddyfile).
+
+You can try out other directives you can find there in the same way we've done it in this tutorial. Just add them to the `Caddyfile` and reload caddy using `sudo systemctl reload caddy`.
+
+I find working with caddy and the `Caddyfile` very easy and intuitive. I hope you do too!
+
+
+# Licence
+
+[MIT](https://github.com/netcup-community/community-tutorials/blob/main/LICENSE)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicence, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Contributor's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+1) The contribution was created in whole or in part by me and I have the right to submit it under the licence indicated
+   in the file; or
+
+2) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate
+   licence and I have the right under that licence to submit that work with modifications, whether created in whole or
+   in part by me, under the same licence (unless I am permitted to submit under a different licence), as indicated in
+   the file; or
+
+3) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not
+   modified it.
+
+4) I understand and agree that this project and the contribution are public and that a record of the contribution (
+   including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be
+   redistributed consistent with this project or the licence(s) involved.

--- a/community-tutorials/setup-caddy-server/02-de.md
+++ b/community-tutorials/setup-caddy-server/02-de.md
@@ -1,0 +1,411 @@
+---
+title: Einrichten des Caddy Servers - Der einfachste Weg zu einer sicheren HTTPS-Verbindung
+description: Caddy ist ein Webserver, der einfach zu bedienen und zu konfigurieren ist. Caddy nutzt sogar automatisch Let's Encrypt Zertifikate, ohne große Konfiguration oder zusätzliche Programme!
+level: [ beginner ]
+updated_at: 2023-09-29
+slug: setup-caddy
+author_name: Anton Mrosek
+author_url: https://github.com/anjomro/
+author_image: https://avatars.githubusercontent.com/u/17234179?v=4
+author_bio:
+tags: [ shell, ssh, linux, caddy, webserver, https, tls, reverse-proxy ]
+netcup_product_url: https://www.netcup.de/bestellen/produkt.php?produkt=2948
+language: de
+available_languages: [ de, en ]
+---
+
+# Einführung
+
+In diesem Tutorial zeige ich dir, wie du den Caddy-Webserver installierst und grundlegend konfigurierst. Außerdem zeige
+ich dir, wie du statische Dateien mit Caddy bereitstellst und wie du einen Reverse Proxy einrichtest, um beispielsweise
+Dienste, die in Docker ausgeführt werden, über HTTPS im Internet verfügbar zu machen.
+
+Caddy ist aufgrund seines Konfigurationsdateiformats einfach zu verwenden und zu konfigurieren. Eine einfache
+Konfigurationsdatei für einen Reverse Proxy mit automatischem HTTPS könnte so aussehen:
+
+```
+my-cool-domain.de {
+
+   reverse_proxy localhost:8080
+
+}
+```
+
+Wir werden später im Detail auf die Caddy-Serverkonfiguration eingehen.
+
+<details>
+<summary>Eine äquivalente Konfiguration für einen Nginx-Server könnte so aussehen (und erfordert zusätzliche Tools wie Certbot):</summary>
+
+```
+server {
+    listen 80;
+    server_name my-cool-domain.de www.my-cool-domain.de;
+
+    location / {
+        proxy_pass http://localhost:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ~ /.well-known/acme-challenge {
+        allow all;
+    }
+
+    location = /.well-known/acme-challenge/ {
+        return 404;
+    }
+
+    listen [::]:443 ssl ipv6only=on;
+    listen 443 ssl;
+    ssl_certificate /etc/letsencrypt/live/my-cool-domain.de/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/my-cool-domain.de/privkey.pem;
+}
+
+```
+
+</details>
+
+<details>
+<summary>Eine äquivalente Konfiguration für einen Apache2-Server könnte so aussehen (auch hier bräuchte man zusätzlich z.B. certbot):</summary>
+
+```
+<VirtualHost *:80>
+    ServerName my-cool-domain.de
+    ServerAlias www.my-cool-domain.de
+
+    ProxyPass / http://localhost:8080/
+    ProxyPassReverse / http://localhost:8080/
+
+    DocumentRoot /var/www/html
+
+    <Directory /var/www/html>
+        Options FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    Alias /.well-known/acme-challenge/ /var/www/html/.well-known/acme-challenge/
+
+</VirtualHost>
+
+
+```
+
+</details>
+
+
+Offensichtlicherweise ist die Caddy-Konfiguration viel einfacher und verständlicher. Caddy kümmert sich auch um das
+Let's
+Encrypt-Zertifikat ohne jegliche zusätzliche Konfiguration!
+
+Also los gehts mit der Einrichtung von Caddy auf deinem eigenen Server!
+
+# Anforderungen
+
+Für die folgende Anleitung benötigst du Folgendes:
+
+- Einen Server (z. B. VPS), auf dem eine aktuelle Version von Ubuntu läuft mit Zugriff über SSH
+    - Der Server benötigt eine öffentliche IPv4- oder IPv6-Adresse. Netcup VPS / RS-Server verfügen immer über IPv4- und
+      IPv6-Adressen.
+    - Die Anleitung könnte auch auf anderen Linux-Distributionen nutzbar sein, insbesondere der Teil über
+      die `Caddyfile`.
+        - Getestet wurde die Anleitung mit Ubuntu 22.04
+- Einen Domainnamen oder eine Subdomain, bei der du die DNS-Einstellungen bearbeiten kannst
+- Optional: Wenn du einen Reverse Proxy mit Caddy erstellen möchtest, benötigst du einen Dienst, der auf deinem Server
+  läuft und den du nach außen freigeben möchtest. Das kann z.B. ein Docker Container sein.
+
+In dieser Anleitung verwenden wir die Domain "my-cool-domain.de" als Beispiel. Wenn nötig solltest du diese durch deine
+eigene Domain / Subdomain ersetzen, z.B. in den Konfigurationsbeispielen.
+
+# Schritt 1 - Einrichten der DNS-Einträge
+
+Um deine Domain mit deinem Server verwenden zu können, musst du die DNS-Einträge so einrichten, dass sie auf die
+öffentliche IPv4- und/oder IPv6-Adresse deines Servers "zeigen". Wenn Einträge für IPv4 und IPv6 vorhanden sind, sucht
+sich der Client aus, ob er
+über IPv4 oder IPv6 eine Verbindung herstellt.
+
+## Schritt 1.1 - Abrufen der IP-Adressen deines Servers
+
+Zuerst müssen wir die öffentlichen IPv4- und IPv6-Adressen deines Servers herausfinden. Das kannst du mit dem folgenden
+Befehl tun:
+
+```bash
+echo -n -e "\n\nIPv4-Adresse:  " && curl -4 ifconfig.co
+echo -n -e "\nIPv6-Adresse:  " && curl -6 ifconfig.co
+```
+
+Notiere dir die IPv4- und IPv6-Adresse deines Servers. Die brauchen wir im nächsten Schritt.
+
+Wenn du etwas wie "IPv6-Adresse:  curl: (7) Couldn't connect to server" siehst, hat dein Server
+möglicherweise keine IPv6-Adresse. In diesem Fall kannst du nur die IPv4-Adresse verwenden, das funktionert auch.
+
+## Schritt 1.2 - Einrichten der DNS-Einträge
+
+Die DNS-Einträge können von deinem DNS-Anbieter geändert werden. Wenn du die Standard-Einstellungen nicht geändert hast,
+handelt es sich höchstwahrscheinlich um den Ort, an dem du deine Domain gekauft hast. Wenn du deine Domain bei Netcup
+gekauft hast, kannst du die DNS-Einträge im Kundenkontrollpanel ändern. Dort musst
+du `Domains` > `my-cool-domain.de` > `DNS` aufrufen.
+
+Füge dann die folgenden Einträge zu den anderen DNS-Einträgen hinzu:
+
+| Typ  | Host | Wert                        |
+|------|------|-----------------------------|
+| A    | @    | IPv4-Adresse deines Servers |
+| AAAA | @    | IPv6-Adresse deines Servers |
+
+Wenn dir entweder IPv4 oder IPv6 fehlt, kannst du den entsprechenden Eintrag weglassen.
+
+## Schritt 1.3 - Überprüfen der DNS-Einträge
+
+Es kann bis zu 24 Stunden dauern, bis die DNS-Einträge aktualisiert sind. Normalerweise dauert es jedoch nur wenige
+Minuten. Du kannst überprüfen, ob die DNS-Einträge erfolgreich aktualisiert wurden, indem du den folgenden Befehl
+verwendest:
+
+```bash
+dig +short my-cool-domain.de
+```
+
+Wenn die IPv4- und/oder IPv6-Adresse deines Servers ausgegeben werden, sind die DNS-Einträge aktualisiert, und du kannst
+mit dem
+nächsten Schritt fortfahren.
+
+# Schritt 2 - Installation von Caddy
+
+## Schritt 2.1 - Hinzufügen des Caddy-Repositorys
+
+Caddy ist nicht in den Standard Ubuntu-Repositories verfügbar. Daher müssen wir
+zuerst das Caddy-Repository hinzufügen. Dafür sind die folgenden Schritte nötig:
+
+- Lade den Signaturschlüssel des Repositorys herunter und installiere ihn, damit die Pakete überprüft werden können:
+    - Gib dein Passwort ein, wenn du dazu aufgefordert wirst (dies gilt auch für die folgenden Befehle):
+
+```bash
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo tee /usr/share/keyrings/caddy.asc
+```
+
+- Installiere das Repository-Listing:
+
+```bash
+echo "deb [signed-by=/usr/share/keyrings/caddy.asc] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main" | sudo tee -a /etc/apt/sources.list.d/caddy-stable.list
+```
+
+- Aktualisiere den Paket-Cache, damit die Pakete aus dem neuen Repository verfügbar sind:
+
+```bash
+sudo apt update
+```
+
+## Schritt 2.2 - Installation von Caddy
+
+Jetzt können wir Caddy mit dem folgenden Befehl installieren:
+
+```bash
+sudo apt install caddy
+```
+
+Super! Du hast Caddy erfolgreich auf deinem Server installiert!
+
+# Schritt 3 - Konfiguration von Caddy
+
+Die Konfigurationsdatei von Caddy, die `Caddyfile`, befindet sich unter `/etc/caddy/Caddyfile`.
+
+## Schritt 3.1 - Überprüfung der Standardkonfiguration und Leeren des `Caddyfile`
+
+Die Standardkonfiguration kannst du wie folgt anzeigen:
+
+```bash
+sudo cat /etc/caddy/Caddyfile
+```
+
+<details>
+<summary>Dein `Caddyfile` sollte so oder so ähnlich aussehen:</summary>
+
+```
+# Das Caddyfile ist eine einfache Möglichkeit, deinen Caddy-Webserver zu konfigurieren.
+#
+# Sofern die Datei nicht mit einem globalen Optionsblock beginnt, ist die erste
+# nicht auskommentierte Zeile immer die Adresse deiner Website.
+#
+# Um deinen eigenen Domainnamen (mit automatischem HTTPS) zu verwenden, stelle sicher,
+# dass die A/AAAA-DNS-Einträge deiner Domäne auf die öffentliche IP dieses Servers
+# richtig zeigen, und ersetze ":80" unten durch deinen Domainnamen.
+
+:80 {
+        # Setze diesen Pfad auf das Verzeichnis deiner Website.
+        root * /usr/share/caddy
+
+        # Aktiviere den statischen Dateiserver.
+        file_server
+
+        # Eine andere häufige Aufgabe ist die Einrichtung eines Reverse-Proxys:
+        # reverse_proxy localhost:8080
+
+        # Oder serviere eine PHP-Website über php-fpm:
+        # php_fastcgi localhost:9000
+}
+
+# Weitere Informationen findest du in der Caddy-Dokumentation:
+# https://caddyserver.com/docs/caddyfile
+
+```
+
+</details>
+
+Um Caddy zu konfigurieren, ist es am einfachsten, mit einer leeren `Caddyfile` zu beginnen und die Konfiguration
+schrittweise hinzuzufügen.
+
+Um die Standardinhalte der `Caddyfile` zu löschen, kannst du folgenden Befehl verwenden:
+
+```bash
+sudo truncate -s 0 /etc/caddy/Caddyfile
+```
+
+Wenn du magsr kannst du überprüfen, ob die `Caddyfile` tatsächlich leer ist:
+
+```bash
+sudo cat /etc/caddy/Caddyfile
+```
+
+## Schritt 3.2 - Hinzufügen der ersten Konfiguration
+
+Jetzt können wir unsere erste Konfiguration zur `Caddyfile` hinzufügen. Wir beginnen mit einer einfachen Konfiguration,
+die die statische HTML-Seite anzeigt, die mit der Caddy-Installation geliefert wurde.
+
+Verwende den folgenden Befehl, um die `Caddyfile` zu öffnen und zu bearbeiten:
+
+```bash
+sudo nano /etc/caddy/Caddyfile
+```
+
+Um die Datei zu speichern, drücke `STRG + S`, um den Editor zu verlassen, drücke `STRG + X`. Pass auf, dass du
+deine Änderungen immer speicherst.
+
+In den folgenden Schritten werden nur Teile der `Caddyfile` gezeigt. Verschiedene Konfigurationen können prinzipiell
+einfach untereinander stehen.
+Du musst jedoch sicherstellen, dass für einen Namen (z.B. `my-cool-domain.de`) nur ein Eintrag vorhanden ist, dies ist
+wichtig für Domänen sowie Subdomänen. Wenn du mehrere
+Einträge für einen Namen hast, wird der Start von Caddy fehlschlagen, da nicht eindeutig ist welcher Eintrag für den
+Namen genuutzt werden soll.
+
+### Schritt 3.2.1 - Deine erste Konfiguration: Servieren von statischen HTML-Dateien
+
+Beginnen wir damit statische HTML-Dateien bereitzustellen. Dazu verwenden wir die Direktive `file_server`.
+
+#### Hinweis: Wenn du eine Firewall eingerichtet hast, musst du eingehende Verbindungen auf den Ports 80 und 443 für Caddy zulassen.
+
+Wenn du magst kannst du das folgende Beispiel zu deiner `Caddyfile` hinzufügen. In dem Verzeichnes liegt eine
+HTML-Datei, die von Caddy als Beispiel mitgeliefert wurde. Denke daran, `my-cool-domain.de` durch deinen
+eigenen Domainnamen oder deine Subdomäne zu ersetzen, bei der du die DNS-Einträge in Schritt 1.2 gesetzt hast.
+
+```
+
+my-cool-domain.de {
+
+   root * /usr/share/caddy
+
+   file_server
+
+}
+
+```
+
+Damit deine Änderungen wirksam werden, musst du Caddy die Konfiguration mit dem folgenden Befehl neu laden lassen:
+
+```bash
+sudo systemctl reload caddy
+```
+
+Um zu überprüfen, ob Caddy läuft und um einige Debugging-Ausgaben anzuzeigen, z. B. wenn ein Fehler in deiner
+`Caddyfile` vorliegt, kannst du den folgenden Befehl verwenden:
+
+```bash
+sudo systemctl status caddy
+```
+
+Nun kannst du deine Domain in deinem Browser öffnen, und du solltest die Standard-Caddy-Seite unter deiner
+Domain/Subdomäne sehen. Gib einfach https://my-cool-domain.de in deinem Browser ein, und du solltest die
+Standard-Caddy-Seite sehen. Wenn das nicht sofort funktioniert, warte ca. eine Minute, da Caddy das TLS-Zertifikat
+anfordern und für deine Domain konfigurieren muss.
+Wenn du genau hinschaust (je nach Browser) siehst du ein Schlosssymbol in der
+Adressleiste, das darauf hinweist, dass die Verbindung über HTTPS verschlüsselt ist. Im Hintergrund hat Caddy ein
+TLS-Zertifikat von Let's Encrypt angefordert und nutzt dies nun um die Seite über HTTPS zu verschlüsseln.
+
+### Schritt 3.2.2 - Optional: Caddy als Reverse Proxy
+
+Wenn auf deinem Server ein Webservice läuft, den du nach außen freigeben möchtest, kannst du Caddy als Reverse Proxy
+verwenden.
+
+Hierfür kannst du die Direktive `reverse_proxy` verwenden. Die `reverse_proxy`-Direktive leitet alle Anfragen an die
+angegebene Adresse weiter.
+
+Wenn du einen Webservice auf Port 8080 auf deinem Server ausführst, kannst du die folgende Konfiguration verwenden, um
+deinen Webservice über deine Domain/Subdomäne über eine verschlüsselte HTTPS-Verbindung öffentlich verfügbar zu machen:
+
+```
+my-cool-domain.de {
+
+   reverse_proxy localhost:8080
+
+}
+```
+
+Stelle sicher, dass du keine anderen Einträge für `my-cool-domain.de` in deiner `Caddyfile` hast, da ansonsten das neu
+laden der `Caddyfile` scheitern wird, wenn mehrere Einträge für einen Namen vorhanden sind.
+
+Um deine Änderungen zu aktivieren, musst du Caddy die Konfiguration mit dem folgenden Befehl neu laden lassen:
+
+```bash
+sudo systemctl reload caddy
+```
+
+# Fazit
+
+Jetzt weißt du, wie du den Server mit zwei grundlegenden Konfigurationen einrichtest. Mit Caddy stehen jedoch
+viele weitere Konfigurationsmöglichkeiten zur Verfügung, und auch die gezeigten Konfigurationen können erweitert werden.
+
+Diese und noch mehr Informationen findest du in der [Caddy-Dokumentation](https://caddyserver.com/docs/caddyfile).
+
+Wenn du magst kannst du andere Direktiven aus der Dokumentation ausprobieren, genauso wie wir die anderen
+Konfigurationen in diesem Tutorial ausprobiert haben.
+Füge die Direktiven einfach zur `Caddyfile` hinzu und lade Caddy mit `sudo systemctl reload caddy` neu.
+
+Ich finde die Arbeit mit Caddy und der `Caddyfile` sehr einfach und intuitiv. Ich hoffe, dir geht es genauso!
+
+
+# Licence
+
+[MIT](https://github.com/netcup-community/community-tutorials/blob/main/LICENSE)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicence, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Contributor's Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+1) The contribution was created in whole or in part by me and I have the right to submit it under the licence indicated
+   in the file; or
+
+2) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate
+   licence and I have the right under that licence to submit that work with modifications, whether created in whole or
+   in part by me, under the same licence (unless I am permitted to submit under a different licence), as indicated in
+   the file; or
+
+3) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not
+   modified it.
+
+4) I understand and agree that this project and the contribution are public and that a record of the contribution (
+   including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be
+   redistributed consistent with this project or the licence(s) involved.

--- a/community-tutorials/setup-caddy-server/02-de.md
+++ b/community-tutorials/setup-caddy-server/02-de.md
@@ -1,22 +1,22 @@
 ---
 title: Einrichten des Caddy Servers - Der einfachste Weg zu einer sicheren HTTPS-Verbindung
-description: Caddy ist ein Webserver, der einfach zu bedienen und zu konfigurieren ist. Caddy nutzt sogar automatisch Let's Encrypt Zertifikate, ohne große Konfiguration oder zusätzliche Programme!
-level: [ beginner ]
+description: Caddy ist ein Webserver, der einfach zu bedienen und zu konfigurieren ist. Caddy nutzt sogar automatisch Let's Encrypt-Zertifikate ohne zusätzliche Konfiguration oder Programme!
+level: [beginner]
 updated_at: 2023-09-29
 slug: setup-caddy
 author_name: Anton Mrosek
 author_url: https://github.com/anjomro/
 author_image: https://avatars.githubusercontent.com/u/17234179?v=4
 author_bio:
-tags: [ shell, ssh, linux, caddy, webserver, https, tls, reverse-proxy ]
+tags: [shell, ssh, linux, caddy, webserver, https, tls, reverse-proxy]
 netcup_product_url: https://www.netcup.de/bestellen/produkt.php?produkt=2948
 language: de
-available_languages: [ de, en ]
+available_languages: [de, en]
 ---
 
 # Einführung
 
-In diesem Tutorial zeige ich dir, wie du den Caddy-Webserver installierst und grundlegend konfigurierst. Außerdem zeige
+In diesem Tutorial zeige ich dir, wie du den Caddy-Webserver installierst und grundlegend konfigurierst. Außerdem erkläre
 ich dir, wie du statische Dateien mit Caddy bereitstellst und wie du einen Reverse Proxy einrichtest, um beispielsweise
 Dienste, die in Docker ausgeführt werden, über HTTPS im Internet verfügbar zu machen.
 
@@ -68,7 +68,7 @@ server {
 </details>
 
 <details>
-<summary>Eine äquivalente Konfiguration für einen Apache2-Server könnte so aussehen (auch hier bräuchte man zusätzlich z.B. certbot):</summary>
+<summary>Eine äquivalente Konfiguration für einen Apache2-Server könnte so aussehen (auch hier bräuchte man zusätzlich z.B. Certbot):</summary>
 
 ```
 <VirtualHost *:80>
@@ -96,27 +96,25 @@ server {
 </details>
 
 
-Offensichtlicherweise ist die Caddy-Konfiguration viel einfacher und verständlicher. Caddy kümmert sich auch um das
-Let's
-Encrypt-Zertifikat ohne jegliche zusätzliche Konfiguration!
+Im Vergleich dazu ist die Caddy-Konfiguration viel einfacher und verständlicher. Zudem kümmert sich Caddy auch um das Let's Encrypt-Zertifikat ohne jegliche zusätzliche Konfiguration!
 
-Also los gehts mit der Einrichtung von Caddy auf deinem eigenen Server!
+Also los geht's mit der Einrichtung von Caddy auf deinem eigenen Server!
 
 # Anforderungen
 
-Für die folgende Anleitung benötigst du Folgendes:
+Für die Anleitungen in diesem Tutorial benötigst du Folgendes:
 
-- Einen Server (z. B. VPS), auf dem eine aktuelle Version von Ubuntu läuft mit Zugriff über SSH
-    - Der Server benötigt eine öffentliche IPv4- oder IPv6-Adresse. Netcup VPS / RS-Server verfügen immer über IPv4- und
+- Einen Server (z. B. VPS), auf dem eine aktuelle Version von Ubuntu läuft, mit Zugriff über SSH
+    - Der Server benötigt eine öffentliche IPv4- oder IPv6-Adresse. netcup VPS / RS-Server verfügen immer über IPv4- und
       IPv6-Adressen.
     - Die Anleitung könnte auch auf anderen Linux-Distributionen nutzbar sein, insbesondere der Teil über
-      die `Caddyfile`.
-        - Getestet wurde die Anleitung mit Ubuntu 22.04
+      das `Caddyfile`.
+    - Getestet wurde die Anleitung mit Ubuntu 22.04.
 - Einen Domainnamen oder eine Subdomain, bei der du die DNS-Einstellungen bearbeiten kannst
 - Optional: Wenn du einen Reverse Proxy mit Caddy erstellen möchtest, benötigst du einen Dienst, der auf deinem Server
   läuft und den du nach außen freigeben möchtest. Das kann z.B. ein Docker Container sein.
 
-In dieser Anleitung verwenden wir die Domain "my-cool-domain.de" als Beispiel. Wenn nötig solltest du diese durch deine
+In dieser Anleitung verwenden wir die Domain "my-cool-domain.de" als Beispiel. Gegebenenfalls solltest du diese durch deine
 eigene Domain / Subdomain ersetzen, z.B. in den Konfigurationsbeispielen.
 
 # Schritt 1 - Einrichten der DNS-Einträge
@@ -124,7 +122,7 @@ eigene Domain / Subdomain ersetzen, z.B. in den Konfigurationsbeispielen.
 Um deine Domain mit deinem Server verwenden zu können, musst du die DNS-Einträge so einrichten, dass sie auf die
 öffentliche IPv4- und/oder IPv6-Adresse deines Servers "zeigen". Wenn Einträge für IPv4 und IPv6 vorhanden sind, sucht
 sich der Client aus, ob er
-über IPv4 oder IPv6 eine Verbindung herstellt.
+eine Verbindung über IPv4 oder IPv6 herstellt.
 
 ## Schritt 1.1 - Abrufen der IP-Adressen deines Servers
 
@@ -138,13 +136,13 @@ echo -n -e "\nIPv6-Adresse:  " && curl -6 ifconfig.co
 
 Notiere dir die IPv4- und IPv6-Adresse deines Servers. Die brauchen wir im nächsten Schritt.
 
-Wenn du etwas wie "IPv6-Adresse:  curl: (7) Couldn't connect to server" siehst, hat dein Server
-möglicherweise keine IPv6-Adresse. In diesem Fall kannst du nur die IPv4-Adresse verwenden, das funktionert auch.
+Wenn du eine Meldung in der Art von "IPv6-Adresse:  curl: (7) Couldn't connect to server" siehst, hat dein Server
+möglicherweise keine IPv6-Adresse. In diesem Fall kannst du nur die IPv4-Adresse verwenden, das funktioniert auch.
 
 ## Schritt 1.2 - Einrichten der DNS-Einträge
 
 Die DNS-Einträge können von deinem DNS-Anbieter geändert werden. Wenn du die Standard-Einstellungen nicht geändert hast,
-handelt es sich höchstwahrscheinlich um den Ort, an dem du deine Domain gekauft hast. Wenn du deine Domain bei Netcup
+handelt es sich höchstwahrscheinlich um den Ort, an dem du deine Domain gekauft hast. Wenn du deine Domain bei netcup
 gekauft hast, kannst du die DNS-Einträge im Kundenkontrollpanel ändern. Dort musst
 du `Domains` > `my-cool-domain.de` > `DNS` aufrufen.
 
@@ -159,7 +157,7 @@ Wenn dir entweder IPv4 oder IPv6 fehlt, kannst du den entsprechenden Eintrag weg
 
 ## Schritt 1.3 - Überprüfen der DNS-Einträge
 
-Es kann bis zu 24 Stunden dauern, bis die DNS-Einträge aktualisiert sind. Normalerweise dauert es jedoch nur wenige
+Prinzipiell kann es bis zu 24 Stunden dauern, bis die DNS-Einträge aktualisiert sind. Normalerweise dauert es jedoch nur wenige
 Minuten. Du kannst überprüfen, ob die DNS-Einträge erfolgreich aktualisiert wurden, indem du den folgenden Befehl
 verwendest:
 
@@ -167,7 +165,7 @@ verwendest:
 dig +short my-cool-domain.de
 ```
 
-Wenn die IPv4- und/oder IPv6-Adresse deines Servers ausgegeben werden, sind die DNS-Einträge aktualisiert, und du kannst
+Wenn die IPv4- und/oder IPv6-Adressen deines Servers ausgegeben werden, sind die DNS-Einträge aktualisiert, und du kannst
 mit dem
 nächsten Schritt fortfahren.
 
@@ -175,7 +173,7 @@ nächsten Schritt fortfahren.
 
 ## Schritt 2.1 - Hinzufügen des Caddy-Repositorys
 
-Caddy ist nicht in den Standard Ubuntu-Repositories verfügbar. Daher müssen wir
+Da Caddy nicht in den Standard Ubuntu-Repositorys verfügbar ist, müssen wir
 zuerst das Caddy-Repository hinzufügen. Dafür sind die folgenden Schritte nötig:
 
 - Lade den Signaturschlüssel des Repositorys herunter und installiere ihn, damit die Pakete überprüft werden können:
@@ -209,7 +207,7 @@ Super! Du hast Caddy erfolgreich auf deinem Server installiert!
 
 # Schritt 3 - Konfiguration von Caddy
 
-Die Konfigurationsdatei von Caddy, die `Caddyfile`, befindet sich unter `/etc/caddy/Caddyfile`.
+Die Konfigurationsdatei von Caddy, das `Caddyfile`, befindet sich unter `/etc/caddy/Caddyfile`.
 
 ## Schritt 3.1 - Überprüfung der Standardkonfiguration und Leeren des `Caddyfile`
 
@@ -223,14 +221,14 @@ sudo cat /etc/caddy/Caddyfile
 <summary>Dein `Caddyfile` sollte so oder so ähnlich aussehen:</summary>
 
 ```
-# Das Caddyfile ist eine einfache Möglichkeit, deinen Caddy-Webserver zu konfigurieren.
+# Mit dem Caddyfile kannst du deinen Caddy-Webserver ganz einfach konfigurieren.
 #
 # Sofern die Datei nicht mit einem globalen Optionsblock beginnt, ist die erste
 # nicht auskommentierte Zeile immer die Adresse deiner Website.
 #
 # Um deinen eigenen Domainnamen (mit automatischem HTTPS) zu verwenden, stelle sicher,
-# dass die A/AAAA-DNS-Einträge deiner Domäne auf die öffentliche IP dieses Servers
-# richtig zeigen, und ersetze ":80" unten durch deinen Domainnamen.
+# dass die A/AAAA-DNS-Einträge deiner Domain auf die öffentliche IP dieses Servers
+# zeigen, und ersetze ":80" unten durch deinen Domainnamen.
 
 :80 {
         # Setze diesen Pfad auf das Verzeichnis deiner Website.
@@ -242,7 +240,7 @@ sudo cat /etc/caddy/Caddyfile
         # Eine andere häufige Aufgabe ist die Einrichtung eines Reverse-Proxys:
         # reverse_proxy localhost:8080
 
-        # Oder serviere eine PHP-Website über php-fpm:
+        # Oder stelle eine PHP-Website über php-fpm bereit:
         # php_fastcgi localhost:9000
 }
 
@@ -253,16 +251,16 @@ sudo cat /etc/caddy/Caddyfile
 
 </details>
 
-Um Caddy zu konfigurieren, ist es am einfachsten, mit einer leeren `Caddyfile` zu beginnen und die Konfiguration
+Um Caddy zu konfigurieren, ist es am einfachsten, mit einem leeren `Caddyfile` zu beginnen und die Konfiguration
 schrittweise hinzuzufügen.
 
-Um die Standardinhalte der `Caddyfile` zu löschen, kannst du folgenden Befehl verwenden:
+Um die Standardinhalte des `Caddyfile` zu löschen, kannst du folgenden Befehl verwenden:
 
 ```bash
 sudo truncate -s 0 /etc/caddy/Caddyfile
 ```
 
-Wenn du magsr kannst du überprüfen, ob die `Caddyfile` tatsächlich leer ist:
+Wenn du magst, kannst du überprüfen, ob das `Caddyfile` tatsächlich leer ist:
 
 ```bash
 sudo cat /etc/caddy/Caddyfile
@@ -270,34 +268,34 @@ sudo cat /etc/caddy/Caddyfile
 
 ## Schritt 3.2 - Hinzufügen der ersten Konfiguration
 
-Jetzt können wir unsere erste Konfiguration zur `Caddyfile` hinzufügen. Wir beginnen mit einer einfachen Konfiguration,
-die die statische HTML-Seite anzeigt, die mit der Caddy-Installation geliefert wurde.
+Jetzt können wir unsere erste Konfiguration zum `Caddyfile` hinzufügen. Wir beginnen mit einer einfachen Konfiguration,
+welche die statische HTML-Seite anzeigt, die mit der Caddy-Installation geliefert wurde.
 
-Verwende den folgenden Befehl, um die `Caddyfile` zu öffnen und zu bearbeiten:
+Verwende den folgenden Befehl, um `Caddyfile` zu öffnen und zu bearbeiten:
 
 ```bash
 sudo nano /etc/caddy/Caddyfile
 ```
 
-Um die Datei zu speichern, drücke `STRG + S`, um den Editor zu verlassen, drücke `STRG + X`. Pass auf, dass du
+Um die Datei zu speichern, drücke `STRG + S`. Um den Editor zu verlassen, drücke `STRG + X`. Pass auf, dass du
 deine Änderungen immer speicherst.
 
-In den folgenden Schritten werden nur Teile der `Caddyfile` gezeigt. Verschiedene Konfigurationen können prinzipiell
+In den folgenden Schritten werden nur Teile des `Caddyfile` gezeigt. Verschiedene Konfigurationen können prinzipiell
 einfach untereinander stehen.
 Du musst jedoch sicherstellen, dass für einen Namen (z.B. `my-cool-domain.de`) nur ein Eintrag vorhanden ist, dies ist
-wichtig für Domänen sowie Subdomänen. Wenn du mehrere
-Einträge für einen Namen hast, wird der Start von Caddy fehlschlagen, da nicht eindeutig ist welcher Eintrag für den
-Namen genuutzt werden soll.
+wichtig für Domains sowie Subdomains. Wenn du mehrere
+Einträge für einen Namen hast, wird der Start von Caddy fehlschlagen, da nicht eindeutig ist, welcher Eintrag für den
+Namen genutzt werden soll.
 
-### Schritt 3.2.1 - Deine erste Konfiguration: Servieren von statischen HTML-Dateien
+### Schritt 3.2.1 - Deine erste Konfiguration: Bereitstellen von statischen HTML-Dateien
 
-Beginnen wir damit statische HTML-Dateien bereitzustellen. Dazu verwenden wir die Direktive `file_server`.
+Beginnen wir damit, statische HTML-Dateien bereitzustellen. Dazu verwenden wir die Direktive `file_server`.
 
 #### Hinweis: Wenn du eine Firewall eingerichtet hast, musst du eingehende Verbindungen auf den Ports 80 und 443 für Caddy zulassen.
 
-Wenn du magst kannst du das folgende Beispiel zu deiner `Caddyfile` hinzufügen. In dem Verzeichnes liegt eine
+Wenn du magst, kannst du das folgende Beispiel zu deinem `Caddyfile` hinzufügen. In dem Verzeichnis liegt eine
 HTML-Datei, die von Caddy als Beispiel mitgeliefert wurde. Denke daran, `my-cool-domain.de` durch deinen
-eigenen Domainnamen oder deine Subdomäne zu ersetzen, bei der du die DNS-Einträge in Schritt 1.2 gesetzt hast.
+eigenen Domainnamen oder die Subdomain zu ersetzen, bei der du die DNS-Einträge in Schritt 1.2 gesetzt hast.
 
 ```
 
@@ -317,7 +315,7 @@ Damit deine Änderungen wirksam werden, musst du Caddy die Konfiguration mit dem
 sudo systemctl reload caddy
 ```
 
-Um zu überprüfen, ob Caddy läuft und um einige Debugging-Ausgaben anzuzeigen, z. B. wenn ein Fehler in deiner
+Um zu überprüfen, ob Caddy läuft und um einige Debugging-Ausgaben anzuzeigen, z. B. wenn ein Fehler in deinem
 `Caddyfile` vorliegt, kannst du den folgenden Befehl verwenden:
 
 ```bash
@@ -328,20 +326,20 @@ Nun kannst du deine Domain in deinem Browser öffnen, und du solltest die Standa
 Domain/Subdomäne sehen. Gib einfach https://my-cool-domain.de in deinem Browser ein, und du solltest die
 Standard-Caddy-Seite sehen. Wenn das nicht sofort funktioniert, warte ca. eine Minute, da Caddy das TLS-Zertifikat
 anfordern und für deine Domain konfigurieren muss.
-Wenn du genau hinschaust (je nach Browser) siehst du ein Schlosssymbol in der
+Wenn du genau hinsiehst (je nach Browser), siehst du ein Schlosssymbol in der
 Adressleiste, das darauf hinweist, dass die Verbindung über HTTPS verschlüsselt ist. Im Hintergrund hat Caddy ein
-TLS-Zertifikat von Let's Encrypt angefordert und nutzt dies nun um die Seite über HTTPS zu verschlüsseln.
+TLS-Zertifikat von Let's Encrypt angefordert und nutzt dieses nun, um die Seite über HTTPS zu verschlüsseln.
 
 ### Schritt 3.2.2 - Optional: Caddy als Reverse Proxy
 
 Wenn auf deinem Server ein Webservice läuft, den du nach außen freigeben möchtest, kannst du Caddy als Reverse Proxy
 verwenden.
 
-Hierfür kannst du die Direktive `reverse_proxy` verwenden. Die `reverse_proxy`-Direktive leitet alle Anfragen an die
+Hierfür verwendest due die Direktive `reverse_proxy`. Die `reverse_proxy`-Direktive leitet alle Anfragen an die
 angegebene Adresse weiter.
 
 Wenn du einen Webservice auf Port 8080 auf deinem Server ausführst, kannst du die folgende Konfiguration verwenden, um
-deinen Webservice über deine Domain/Subdomäne über eine verschlüsselte HTTPS-Verbindung öffentlich verfügbar zu machen:
+deinen Webservice über deine Domain / Subdomain über eine verschlüsselte HTTPS-Verbindung öffentlich verfügbar zu machen:
 
 ```
 my-cool-domain.de {
@@ -351,8 +349,8 @@ my-cool-domain.de {
 }
 ```
 
-Stelle sicher, dass du keine anderen Einträge für `my-cool-domain.de` in deiner `Caddyfile` hast, da ansonsten das neu
-laden der `Caddyfile` scheitern wird, wenn mehrere Einträge für einen Namen vorhanden sind.
+Stelle sicher, dass du keine anderen Einträge für `my-cool-domain.de` in deinem `Caddyfile` hast, da das neuerliche
+Laden des `Caddyfile` scheitern wird, wenn mehrere Einträge für einen Namen vorhanden sind.
 
 Um deine Änderungen zu aktivieren, musst du Caddy die Konfiguration mit dem folgenden Befehl neu laden lassen:
 
@@ -367,14 +365,14 @@ viele weitere Konfigurationsmöglichkeiten zur Verfügung, und auch die gezeigte
 
 Diese und noch mehr Informationen findest du in der [Caddy-Dokumentation](https://caddyserver.com/docs/caddyfile).
 
-Wenn du magst kannst du andere Direktiven aus der Dokumentation ausprobieren, genauso wie wir die anderen
+Wenn du magst, kannst du andere Direktiven aus der Dokumentation ausprobieren, genauso wie wir die anderen
 Konfigurationen in diesem Tutorial ausprobiert haben.
-Füge die Direktiven einfach zur `Caddyfile` hinzu und lade Caddy mit `sudo systemctl reload caddy` neu.
+Füge die Direktiven einfach zum `Caddyfile` hinzu und lade Caddy mit `sudo systemctl reload caddy` neu.
 
-Ich finde die Arbeit mit Caddy und der `Caddyfile` sehr einfach und intuitiv. Ich hoffe, dir geht es genauso!
+Ich finde das Arbeiten mit Caddy und dem `Caddyfile` sehr einfach und intuitiv. Ich hoffe, dir geht es genauso!
 
 
-# Licence
+# License
 
 [MIT](https://github.com/netcup-community/community-tutorials/blob/main/LICENSE)
 
@@ -395,12 +393,12 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 
 By making a contribution to this project, I certify that:
 
-1) The contribution was created in whole or in part by me and I have the right to submit it under the licence indicated
+1) The contribution was created in whole or in part by me and I have the right to submit it under the license indicated
    in the file; or
 
 2) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate
-   licence and I have the right under that licence to submit that work with modifications, whether created in whole or
-   in part by me, under the same licence (unless I am permitted to submit under a different licence), as indicated in
+   license and I have the right under that license to submit that work with modifications, whether created in whole or
+   in part by me, under the same license (unless I am permitted to submit under a different license), as indicated in
    the file; or
 
 3) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not
@@ -408,4 +406,4 @@ By making a contribution to this project, I certify that:
 
 4) I understand and agree that this project and the contribution are public and that a record of the contribution (
    including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be
-   redistributed consistent with this project or the licence(s) involved.
+   redistributed consistent with this project or the license(s) involved.


### PR DESCRIPTION
I have created a simple tutorial that explains a bit about how to setup and configure the `caddy` server, as only saw tutorials about `apache2` and `nginx` listed on the tutorial site.


### Obligatory Statement:
I have read and understood the Contributor's Certificate of Origin at the end of the [template](https://github.com/netcup-community/community-tutorials/blob/main/TEMPLATE.md) and I hereby certify that I meet the contribution criteria described in it.