### PR TITLE
Update install uptime kuma standalone tutorial

### DIFF
--- a/community-tutorials/how-to-install-uptime-kuma/01-en.md
+++ b/community-tutorials/how-to-install-uptime-kuma/01-en.md
@@ -2,7 +2,7 @@
 title: Setup of Standalone Uptime Kuma on Ubuntu with a Reverse Proxy
 description: Learn how to set up Uptime Kuma, a free and open source uptime monitor, on Ubuntu and use nginx as a reverse proxy to operate it securely.
 level: beginner
-updated_at: 2023-04-20
+updated_at: 2023-11-28
 slug: ubuntu-uptime-kuma-standalone-installation
 author_name: Konstantin Protzen
 author_url: https://github.com/cuzimbisonratte
@@ -23,7 +23,7 @@ This tool is very useful for getting notified when a service is down.
 
 The time needed to follow this tutorial is approximately 10 - 20 minutes.
 
-The tutorial was tested on Ubuntu 22.04 (April 2023).
+The tutorial was tested on Ubuntu 22.04 (November 2023).
 
 The tutorial uses the example ip `123.123.123.123`.  
 This hostname needs to be replaced by the name of your own server when you perform the steps described below.  

--- a/community-tutorials/how-to-install-uptime-kuma/01-en.md
+++ b/community-tutorials/how-to-install-uptime-kuma/01-en.md
@@ -8,13 +8,15 @@ author_name: Konstantin Protzen
 author_url: https://github.com/cuzimbisonratte
 author_image: https://github.com/cuzimbisonratte.png
 author_bio:
-tags: [linux, ubuntu, uptime, monitoring, kuma, nodejs, nginx, proxy, reverse-proxy] 
+tags:
+  [linux, ubuntu, uptime, monitoring, kuma, nodejs, nginx, proxy, reverse-proxy]
 netcup_product_url: https://www.netcup.de/bestellen/produkt.php?produkt=2991
 language: en
 available_languages: [en, de]
 ---
 
 # Introduction
+
 This tutorial describes how to set up an Uptime Kuma instance on Ubuntu 20.04. Uptime Kuma is a free and open source uptime monitor. It is a self-hosted alternative to services like Uptime Robot or StatusCake. It is available as a Docker image, but this tutorial describes how to set up an instance without Docker (as a standalone).
 
 This tool is very useful for getting notified when a service is down.
@@ -30,7 +32,8 @@ We will also use the domain `example.com` in this tutorial. Replace it with your
 We will not use the installation script provided by Uptime Kuma, because it is sometimes buggy.
 
 # Requirements
-For a 'small instance' (up to 20 monitored services) VPS 200 is sufficient.  
+
+For a 'small instance' (up to 20 monitored services) VPS 200 is sufficient.
 
 I recommend setting up the instance on a VPS 200.  
 If you feel like the instance is slowing down, you can always update to a bigger server trough the CCP.
@@ -39,9 +42,10 @@ The server needs to have Ubuntu 20.04 and SSH already installed.
 
 <hr>
 
-You will also need a domain. A domain used in a webhosting package is sufficient. (You can still use it for your webhosting, because we will use a subdomain.)  
+You will also need a domain. A domain used in a webhosting package is sufficient. (You can still use it for your webhosting, because we will use a subdomain.)
 
-# Step 1 - Finding out the IP of your server  
+# Step 1 - Finding out the IP of your server
+
 1. Log in to the SCP (ServerControlPanel) under https://www.servercontrolpanel.de.
 2. Click on the server you want to use.
 3. If you are already on the "General" tab, you'll see a pane labeled "Network" in the bottom right corner.
@@ -49,33 +53,39 @@ You will also need a domain. A domain used in a webhosting package is sufficient
 5. Write the IP of your server down.
 
 # Step 2 - Configuring DNS
+
 1. Log in to the CCP (CustomerControlPanel) under https://www.customercontrolpanel.de.
 2. In the sidebar on the left, click on "Domains".
 3. Find the domain you want to use and click on the magnifying glass symbol next to it.
 4. In the new window, click on "DNS".
 5. Scroll down until there are empty fields.
-6. In the first field, write your subdomain name (I recommend using "status"). 
+6. In the first field, write your subdomain name (I recommend using "status").
 7. In the dropdown menu, select `A`.
 8. In the last field, enter the IP of your server (from Step 1).
 9. Click on "Save DNS records".
 
 # Step 3 - Preparing the server
+
 First you need to log in to your server via SSH, then follow these steps:
 
 1. Enter `sudo -s` to get root privileges.
 2. If asked for your password, enter it and press `Enter`.
 3. Now enter `apt update -y && apt upgrade -y` to update the server.
 4. If a pink window appears, press `Enter` once to continue.
-5. Enter `curl https://deb.nodesource.com/setup_16.x -o /tmp/nodesource_setup.sh && bash /tmp/nodesource_setup.sh` to install NodeJS 16.
-6. Enter `apt install nodejs curl nginx git -y` to install all the required software.
-7. If a pink window appears, press `Enter` once to continue.
-8. Enter `npm install npm -g` to update npm.
-9. If a pink window appears, press `Enter` once to continue.
-10. Enter `npm install pm2 -g && pm2 completion install` to install pm2 and its autocompletion.
-11. Enter `exit` and press `Enter` to leave root privileges.
+5. Enter `apt install curl nginx git -y` to install all the required software.
+6. Enter `adduser uptimekuma --gecos "" --disabled-password && su uptimekuma` to create a new user and switch to it.
 
-# Step 4 - Installing Uptime Kuma
-Enter the following command to install Uptime Kuma:  
+# Step 4 - Installing Node.js
+
+1. Enter `cd && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash` to install NVM.
+2. Enter `source ~/.bashrc` to install all the required software.
+3. Enter `nvm install 18 && nvm use 18` to install and activate NodeJS 18.
+4. Enter `npm install npm pm2 -g && pm2 completion install` to install pm2 and its auto completion.
+
+# Step 5 - Installing Uptime Kuma
+
+Enter the following command to install Uptime Kuma:
+
 1. Enter `git clone https://github.com/louislam/uptime-kuma.git` to clone the repository.
 2. Change directory by executing `cd uptime-kuma`.
 3. Enter `npm run setup` to install all dependencies.
@@ -84,16 +94,18 @@ Enter the following command to install Uptime Kuma:
 Once you see "Listening on 3001" in the terminal, go to your IP on Port 3001 (e.g. `123.123.123.123:3001`) in your browser.
 If you see the Uptime Kuma setup screen, you have successfully installed Uptime Kuma. Please stop the server by pressing `Ctrl + C` in the terminal once. You have to wait a little while until the server stops.
 
-# Step 5 - Reverse Proxy with nginx
+# Step 6 - Reverse Proxy with nginx
+
 1. Enter `sudo -s` to get root privileges.
 2. If asked for your password, enter it and press `Enter`.
-3. Enter `nano /etc/nginx/sites-available/uptime-kuma` to create a new nginx config file.
+3. Enter `nano /etc/nginx/sites-available/uptimekuma` to create a new nginx config file.
 4. Paste the following code into the file:
+
 ```nginx
 server  {
     listen 80;
     # Remove '#' in the next line to enable IPv6
-    # listen [::]:80;
+    listen [::]:80;
     server_name    sub.domain.com;
     location / {
         proxy_pass         http://localhost:3001;
@@ -104,18 +116,21 @@ server  {
     }
 }
 ```
+
 5. Replace `sub.domain.com` with your subdomain (e.g. `status.example.com`).
 6. Exit the file by pressing `Ctrl + X` and then `Y` and then `Enter`.
-7. Enter `ln -s /etc/nginx/sites-available/uptime-kuma /etc/nginx/sites-enabled/uptime-kuma` to enable the config file.
+7. Enter `ln -s /etc/nginx/sites-available/uptimekuma /etc/nginx/sites-enabled/uptimekuma` to enable the config file.
 8. Enter `nginx -t` to test the config file.
 9. If you see `test is successful`, you can reload nginx by entering `systemctl reload nginx`.
 
-# Step 6 - Setting up Uptime Kuma to start on boot
+# Step 7 - Setting up Uptime Kuma to start on boot
+
 We want to start Uptime Kuma automatically when the server starts.  
 This is useful when the server reboots, as we cannot monitor the server running Kuma. When it is restarted, Kuma will also be restarted.
 
-1. Enter `nano /etc/systemd/system/uptime-kuma.service` to create a new systemd service file.
+1. Enter `nano /etc/systemd/system/uptimekuma.service` to create a new systemd service file.
 2. Paste the following code into the file:
+
 ```systemd
 [Unit]
 Description=Uptime-Kuma - A free and open source uptime monitoring solution
@@ -124,43 +139,42 @@ After=network.target
 
 [Service]
 Type=simple
-User=[REPLACE_WITH_USERNAME]
-WorkingDirectory=/home/[REPLACE_WITH_USERNAME]/uptime-kuma
-ExecStart=/usr/bin/npm run start-server
+User=uptimekuma
+WorkingDirectory=/home/uptimekuma/uptime-kuma
+ExecStart=/home/uptimekuma/.nvm/versions/node/v18.18.2/bin/node /home/uptimekuma/uptime-kuma/server/server.js
 Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
 ```
-3. Replace `[REPLACE_WITH_USERNAME]` with the user under which you want to run Uptime Kuma (we don't want to run it as root, so please run it as your SSH login user or create a new user).
-4. Exit the file by pressing `Ctrl + X` and then `Y` and then `Enter`.
-5. Enter `systemctl daemon-reload` to reload the systemd daemon.
-6. Enter `systemctl enable uptime-kuma` to enable the service.
-7. Enter `systemctl start uptime-kuma` to start the service.
 
-# Step 7 - Setting up HTTPS
+3. Exit the file by pressing `Ctrl + X` and then `Y` and then `Enter`.
+4. Enter `systemctl daemon-reload` to reload the systemd daemon.
+5. Enter `systemctl enable uptime-kuma` to enable the service.
+6. Enter `systemctl start uptime-kuma` to start the service.
+
+# Step 8 - Setting up HTTPS
+
 1. Enter `snap install --classic certbot` to install CertBot.
 2. Enter `certbot --nginx` to start the CertBot setup.
 3. I recommend using these settings:
-    1. Enter your email address.
-    2. Yes (Terms of Service)
-    3. No (Advertisement)
-    4. Press `Enter` to select the only option (your domain).
-    5. This process can take a while, so please be patient.
-    
-# Step 8 - Setting up the Firewall
+   1. Enter your email address.
+   2. Yes (Terms of Service)
+   3. No (Advertisement)
+   4. Press `Enter` to select the only option (your domain).
+   5. This process can take a while, so please be patient.
+
+# Step 9 - Setting up the Firewall
+
 We need a firewall to protect our server from unwanted connections.
 
 We will use `ufw` (Uncomplicated Firewall) to set up the firewall, because it is easy to use and configure and is also pre-installed on Ubuntu.
 
-1. Enter `ufw allow ssh` to allow SSH connections.
-2. Enter `ufw allow http` to allow HTTP connections.
-3. Enter `ufw allow https` to allow HTTPS connections.
-4. Enter `ufw enable` to enable the firewall.
-5. Press `Y` and then `Enter` to confirm.
+1. Enter `ufw allow ssh && ufw allow http && ufw allow https && ufw enable` to setup the firewall and then enable it.
+2. Press `Y` and then `Enter` to confirm.
 
+# Step 10 - Setting up Uptime Kuma
 
-# Step 9 - Setting up Uptime Kuma
 1. Open your browser and go to your subdomain (e.g. `https://status.example.com`).
 2. You should see the Uptime Kuma setup screen.
 3. Enter your username and password, also choose the right language. The username is case sensitive!
@@ -168,12 +182,16 @@ We will use `ufw` (Uncomplicated Firewall) to set up the firewall, because it is
 5. In the top right corner, click on the dropdown menu and select "Settings".
 6. In the "General" tab under "Primary Base URL", click on "Auto Get" so that the URL is automatically set.
 
-If this works, you should now restart the server and check if everything starts as it should. To do this, execute `shutdown -r now`. After executing the command, you can close the SSH connection.
+If this works, you should now restart the server and check if everything starts automatically as it should. To do this, execute `shutdown -r now`. After executing the command, you can close the SSH connection.
 
 # Conclusion
-Now you have successfully installed Uptime Kuma and set it up to start on boot.  
+
+Now you have successfully installed Uptime Kuma and set it up to start on boot.
 
 From now on your Kuma instance will be available under your subdomain (e.g. `https://status.example.com`).
+
+If you want to update Uptime-Kuma, you can follow the tutorial [Update Your Uptime Kuma Instance](https://community.netcup.com/en/tutorials/update-uptime-kuma) folgen.  
+Wenn du Alerts einrichten möchtest, kannst du dem Tutorial [Setup of Uptime Kuma Real-Time Alerts](https://community.netcup.com/en/tutorials/uptime-kuma-notification-setup) folgen.
 
 Thank you for using this tutorial!
 
@@ -188,12 +206,13 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 # Contributor's Certificate of Origin
+
 By making a contribution to this project, I certify that:
 
- 1) The contribution was created in whole or in part by me and I have the right to submit it under the licence indicated in the file; or
+1.  The contribution was created in whole or in part by me and I have the right to submit it under the licence indicated in the file; or
 
- 2) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate licence and I have the right under that licence to submit that work with modifications, whether created in whole or in part by me, under the same license (unless I am permitted to submit under a different licence), as indicated in the file; or
+2.  The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate licence and I have the right under that licence to submit that work with modifications, whether created in whole or in part by me, under the same license (unless I am permitted to submit under a different licence), as indicated in the file; or
 
- 3) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+3.  The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
 
- 4) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the licence(s) involved.
+4.  I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the licence(s) involved.

--- a/community-tutorials/how-to-install-uptime-kuma/01-en.md
+++ b/community-tutorials/how-to-install-uptime-kuma/01-en.md
@@ -104,7 +104,6 @@ If you see the Uptime Kuma setup screen, you have successfully installed Uptime 
 ```nginx
 server  {
     listen 80;
-    # Remove '#' in the next line to enable IPv6
     listen [::]:80;
     server_name    sub.domain.com;
     location / {

--- a/community-tutorials/how-to-install-uptime-kuma/02-de.md
+++ b/community-tutorials/how-to-install-uptime-kuma/02-de.md
@@ -107,7 +107,6 @@ Wenn du den Einrichtungsbildschirm von Uptime Kuba siehst, hast du Uptime Kuma e
 ```nginx
 server  {
     listen 80;
-    # Remove '#' in the next line to enable IPv6
     listen [::]:80;
     server_name    sub.domain.com;
     location / {

--- a/community-tutorials/how-to-install-uptime-kuma/02-de.md
+++ b/community-tutorials/how-to-install-uptime-kuma/02-de.md
@@ -2,7 +2,7 @@
 title: Einrichtung von Standalone Uptime Kuma auf Ubuntu mit einem Reverse-Proxy
 description: Lerne, wie du Uptime Kuma (ein kostenloser und quelloffener Uptime Monitor) auf Ubuntu einrichten und Nginx als Reverse Proxy verwenden kannst.
 level: beginner
-updated_at: 2023-04-20
+updated_at: 2023-11-28
 slug: ubuntu-uptime-kuma-standalone-installation
 author_name: Konstantin Protzen
 translator_url: https://github.com/cuzimbisonratte
@@ -25,7 +25,7 @@ Es ist sehr praktisch, benachrichtigt zu werden, wenn ein Dienst ausgefallen ist
 
 Der Zeitbedarf für dieses Tutorial liegt bei etwa 10 - 20 Minuten.
 
-Das Tutorial wurde auf Ubuntu 22.04 (April 2023) getestet.
+Das Tutorial wurde auf Ubuntu 22.04 (November 2023) getestet.
 
 Das Tutorial verwendet die Beispiel-IP `123.123.123.123`.  
 Dieser Hostname muss durch den Namen deines eigenen Servers ersetzt werden, wenn du dem in diesem Tutorial beschriebenen Arbeitsablauf folgst.  

--- a/community-tutorials/how-to-install-uptime-kuma/02-de.md
+++ b/community-tutorials/how-to-install-uptime-kuma/02-de.md
@@ -5,18 +5,20 @@ level: beginner
 updated_at: 2023-04-20
 slug: ubuntu-uptime-kuma-standalone-installation
 author_name: Konstantin Protzen
-translator_url: 
+translator_url: https://github.com/cuzimbisonratte
 translator_name: Konstantin Protzen
 author_url: https://github.com/cuzimbisonratte
 author_image: https://github.com/cuzimbisonratte.png
 author_bio:
-tags: [linux, ubuntu, uptime, monitoring, kuma, nodejs, nginx, proxy, reverse-proxy] 
+tags:
+  [linux, ubuntu, uptime, monitoring, kuma, nodejs, nginx, proxy, reverse-proxy]
 netcup_product_url: https://www.netcup.de/bestellen/produkt.php?produkt=2991
 language: de
 available_languages: [en, de]
 ---
 
 # Einleitung
+
 Dieses Tutorial beschreibt, wie man eine Uptime Kuma Instanz unter Ubuntu 20.04 einrichtet. Uptime Kuma ist ein freier und quelloffener Uptime-Monitor. Es ist eine selbstgehostete Alternative zu Diensten wie Uptime Robot oder StatusCake. Uptime Kuma ist als Docker-Image verfügbar, aber dieses Tutorial beschreibt, wie man eine Instanz ohne Docker (als Standalone) einrichtet.
 
 Es ist sehr praktisch, benachrichtigt zu werden, wenn ein Dienst ausgefallen ist.
@@ -32,7 +34,8 @@ Wir werden in diesem Lehrgang auch die Domain `example.com` verwenden. Ersetze d
 Wir werden nicht das von Uptime Kuma bereitgestellte Installationsskript verwenden, da es manchmal Fehler verursacht.
 
 # Anforderungen
-Für eine "kleine Instanz" (bis zu 20 überwachte Dienste) ist ein VPS 200 ausreichend.  
+
+Für eine "kleine Instanz" (bis zu 20 überwachte Dienste) ist ein VPS 200 ausreichend.
 
 Ich empfehle, die Instanz auf einem VPS 200 einzurichten.  
 Wenn du das Gefühl hast, dass die Instanz zu langsam ist, kannst du jederzeit über das CCP auf einen größeren Server updaten.
@@ -41,9 +44,11 @@ Auf dem Server müssen Ubuntu 20.04 und SSH bereits installiert sein.
 
 <hr>
 
-Außerdem brauchst du eine Domain, wobei eine Domain aus einem Webhosting-Paket ausreicht. 
+Außerdem brauchst du eine Domain, wobei eine Domain aus einem Webhosting-Paket ausreicht.
 (Du kannst die Domain trotzdem mit deinem Webhosting nutzen, da wir eine Subdomain verwenden werden.)
+
 # Schritt 1 - IP deines Servers ermitteln
+
 1. Melde dich im SCP (ServerControlPanel) unter https://www.servercontrolpanel.de an.
 2. Klicke auf den Server, den du verwenden möchtest.
 3. Wenn du dich bereits im Tab "Allgemein" befindest, gibt es unten rechts ein "Netzwerk"-Fenster.
@@ -51,30 +56,39 @@ Außerdem brauchst du eine Domain, wobei eine Domain aus einem Webhosting-Paket 
 5. Notiere dir diese Adresse.
 
 # Schritt 2 - DNS konfigurieren
+
 1. Melde dich im CCP (CustomerControlPanel) unter https://www.customercontrolpanel.de an.
 2. Klicke in der Seitenleiste auf der linken Seite auf "Domains".
 3. Suche die gewünschte Domain und klicke auf die Lupe neben der Domain.
 4. In dem neuen Fenster klicke auf "DNS".
 5. Scrolle nach unten, bis es leere Felder gibt.
-6. Schreibe in das erste Feld deinen Subdomain-Namen (ich empfehle "status" oder einen anderen leicht merkbaren Namen). 
+6. Schreibe in das erste Feld deinen Subdomain-Namen (ich empfehle "status" oder einen anderen leicht merkbaren Namen).
 7. Wähle im Dropdown-Menü "A".
 8. In das letzte Feld schreibst du die IP deines Servers (aus Schritt 1).
 9. Klicke auf "DNS-Einträge speichern".
 
 # Schritt 3 - Server vorbereiten
+
 Zuerst musst du dich über SSH in deinen Server einloggen.
 
 1. Gib `sudo -s` ein, um Root-Rechte zu erhalten.
 2. Gib dein Passwort ein und drücke `Enter`.
 3. Gib nun `apt update -y && apt upgrade -y` ein, um den Server zu aktualisieren.
 4. Falls ein rosafarbenes Fenster erscheint, drücke einmal `Enter` um fortzufahren.
-5. Gib `curl https://deb.nodesource.com/setup_16.x -o /tmp/nodesource_setup.sh && bash /tmp/nodesource_setup.sh` ein, um NodeJS 16 zu installieren.
-6. Gib `apt install nodejs npm curl nginx git -y` ein, um alle benötigte Software zu installieren.
-7. Gib `npm install pm2 -g && pm2 completion install` ein, um pm2 und seine Autovervollständigung zu installieren.
-8. Gib `exit` ein und drücke `Enter`, um die Root-Rechte zu verlassen.
+5. Gib `apt install curl nginx git -y` ein, um alle benötigte Software zu installieren.
+6. Gib `adduser uptimekuma --gecos "" --disabled-password && su uptimekuma` ein, um einen neuen Benutzer zu erstellen und zu diesem zu wechseln.
 
-# Schritt 4 - Uptime Kuma installieren
-Gib den folgenden Befehl ein, um Uptime Kuma zu installieren:  
+# Schritt 4 - NodeJS installieren
+
+1. Gib `cd && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash` ein, um NVM zu installieren.
+2. Gib `source ~/.bashrc` ein, um alle benötigte Software zu installieren.
+3. Gib `nvm install 18 && nvm use 18` ein, um NodeJS 18 zu installieren und zu aktivieren.
+4. Gib `npm install npm pm2 -g && pm2 completion install` ein, um pm2 und seine Autovervollständigung zu installieren.
+
+# Schritt 5 - Uptime Kuma installieren
+
+Gib den folgenden Befehl ein, um Uptime Kuma zu installieren:
+
 1. Gib `git clone https://github.com/louislam/uptime-kuma.git` ein, um das Repository zu klonen.
 2. Wechsle das Verzeichnis, indem du `cd uptime-kuma` ausführst.
 3. Gib `npm run setup` ein, um alle Abhängigkeiten zu installieren.
@@ -83,16 +97,18 @@ Gib den folgenden Befehl ein, um Uptime Kuma zu installieren:
 Sobald du "Listening on 3001" im Terminal siehst, gehe zu deiner IP auf Port 3001 (z.B. `123.123.123.123:3001`) in deinem Browser.
 Wenn du den Einrichtungsbildschirm von Uptime Kuba siehst, hast du Uptime Kuma erfolgreich installiert. Bitte stoppe den Server, indem du einmal `Strg + C` im Terminal drückst und kurz wartest, bis der Server stoppt.
 
-# Schritt 5 - Reverse Proxy mit nginx einrichten
-1. Gib `sudo -s` ein, um Root-Rechte zu erhalten.
+# Schritt 6 - Reverse Proxy mit nginx einrichten
+
+1. Gib `exit` ein, um Root-Rechte zu erhalten.
 2. Wenn du nach deinem Passwort gefragt wirst, gib es ein und drücke `Enter`.
-3. Gib `nano /etc/nginx/sites-available/uptime-kuma` ein, um eine neue nginx-Konfigurationsdatei zu erstellen.
+3. Gib `nano /etc/nginx/sites-available/uptimekuma` ein, um eine neue nginx-Konfigurationsdatei zu erstellen.
 4. Füge den folgenden Code in diese Datei ein:
+
 ```nginx
 server  {
     listen 80;
     # Remove '#' in the next line to enable IPv6
-    # listen [::]:80;
+    listen [::]:80;
     server_name    sub.domain.com;
     location / {
         proxy_pass         http://localhost:3001;
@@ -103,19 +119,22 @@ server  {
     }
 }
 ```
+
 5. Ersetze "sub.domain.com" durch deine Subdomain (z.B. "status.example.com").
 6. Verlasse die Datei durch Drücken von `Strg + X` und dann `Y` und dann `Enter`.
-7. Gib `ln -s /etc/nginx/sites-available/uptime-kuma /etc/nginx/sites-enabled/uptime-kuma` ein, um die Konfigurationsdatei zu aktivieren.
+7. Gib `ln -s /etc/nginx/sites-available/uptimekuma /etc/nginx/sites-enabled/uptimekuma` ein, um die Konfigurationsdatei zu aktivieren.
 8. Gib `nginx -t` ein, um die Konfigurationsdatei zu testen.
 9. Wenn du siehst, dass `Test erfolgreich ist`, kannst du nginx neu laden, indem du `systemctl reload nginx` eingibst.
 
-# Schritt 6 - Uptime Kuma zum Starten beim Booten einrichten
+# Schritt 7 - Uptime Kuma zum Starten beim Booten einrichten
+
 Wir wollen Uptime Kuma automatisch starten, wenn der Server startet.  
 Dies ist nützlich, wenn der Server neu gestartet wird.  
 Vor allem, weil wir den Server, auf dem Kuma läuft, nicht selbst überwachen können. Wenn er also neu gestartet wird, startet auch Kuma neu.
 
-1. Gib `nano /etc/systemd/system/uptime-kuma.service` ein, um eine neue systemd-Dienstdatei zu erstellen.
+1. Gib `nano /etc/systemd/system/uptimekuma.service` ein, um eine neue systemd-Dienstdatei zu erstellen.
 2. Füge den folgenden Code in diese Datei ein:
+
 ```systemd
 [Unit]
 Description=Uptime-Kuma - A free and open source uptime monitoring solution
@@ -124,43 +143,42 @@ After=network.target
 
 [Service]
 Type=simple
-User=[REPLACE_WITH_USERNAME]
-WorkingDirectory=/home/[REPLACE_WITH_USERNAME]/uptime-kuma
-ExecStart=/usr/bin/npm run start-server
+User=uptimekuma
+WorkingDirectory=/home/uptimekuma/uptime-kuma
+ExecStart=/home/uptimekuma/.nvm/versions/node/v18.18.2/bin/node /home/uptimekuma/uptime-kuma/server/server.js
 Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
 ```
-3. Ersetze `[REPLACE_WITH_USERNAME]` mit dem Benutzer, unter den du Uptime Kuma laufen lassen willst (wir wollen Uptime Kuma nicht als root laufen lassen, also führe es bitte als dein SSH Login-Benutzer aus oder erstelle einen neuen Benutzer).
-4. Verlasse die Datei, indem du "Strg + X" und dann "Y" und dann "Enter" drückst.
-5. Gib `systemctl daemon-reload` ein, um den systemd-Daemon neu zu laden.
-6. Gib `systemctl enable uptime-kuma` ein, um den Dienst zu aktivieren.
-7. Gib `systemctl start uptime-kuma` ein, um den Dienst zu starten.
 
-# Schritt 7 - HTTPS einrichten
+3. Verlasse die Datei, indem du "Strg + X" und dann "Y" und dann "Enter" drückst.
+4. Gib `systemctl daemon-reload` ein, um den systemd-Daemon neu zu laden.
+5. Gib `systemctl enable uptimekuma` ein, um den Dienst zu aktivieren.
+6. Gib `systemctl start uptimekuma` ein, um den Dienst zu starten.
+
+# Schritt 8 - HTTPS einrichten
+
 1. Gib `snap install --classic certbot` ein, um certbot zu installieren.
 2. Gib `certbot --nginx` ein, um das certbot-Setup zu starten.
 3. Ich schlage vor, diese Einstellungen zu verwenden:
-    1. Gib deine E-Mail-Adresse ein.
-    2. Ja (Servicebedingungen)
-    3. Nein (Werbung)
-    4. Drücke "Enter", um die einzige Option auszuwählen (deine Domain).
-    5. Dieser Vorgang kann eine Weile dauern, also bitte hab etwas Geduld.
-    
-# Schritt 8 - Firewall einrichten
+   1. Gib deine E-Mail-Adresse ein.
+   2. Ja (Servicebedingungen)
+   3. Nein (Werbung)
+   4. Drücke "Enter", um die einzige Option auszuwählen (deine Domain).
+   5. Dieser Vorgang kann eine Weile dauern, also bitte hab etwas Geduld.
+
+# Schritt 9 - Firewall einrichten
+
 Wir brauchen eine Firewall, um unseren Server vor unerwünschten Verbindungen zu schützen.
 
 Wir werden `ufw` (Uncomplicated Firewall) verwenden, um die Firewall einzurichten, da sie einfach zu benutzen und zu konfigurieren ist und außerdem auf Ubuntu vorinstalliert ist.
 
-1. Gib `ufw allow ssh` ein, um SSH-Verbindungen zu erlauben.
-2. Gib `ufw allow http` ein, um HTTP-Verbindungen zu erlauben.
-3. Gib `ufw allow https` ein, um HTTPS-Verbindungen zu erlauben.
-4. Gib `ufw enable` ein, um die Firewall zu aktivieren.
-5. Drücke zur Bestätigung`Y` und dann `Enter`.
+1. Gib `ufw allow ssh && ufw allow http && ufw allow https && ufw enable` ein um die Firewall einzurichten und zu starten.
+2. Drücke zur Bestätigung `Y` und dann `Enter`.
 
+# Schritt 10 - Uptime Kuma einrichten
 
-# Schritt 9 - Uptime Kuma einrichten
 1. Öffne deinen Browser und gehe zu deiner Subdomain (z.B. `https://status.example.com`).
 2. Du solltest nun den Uptime Kuma Einrichtungsbildschirm sehen.
 3. Gib deinen Benutzernamen und dein Passwort ein und wähle die richtige Sprache aus (beim Benutzernamen wird zwischen Groß- und Kleinschreibung unterschieden).
@@ -171,9 +189,13 @@ Wir werden `ufw` (Uncomplicated Firewall) verwenden, um die Firewall einzurichte
 Wenn dies funktioniert, solltest du nun den Server neu starten und überprüfen, ob alles so startet, wie es sollte. Führe dazu "shutdown -r now" aus. Nach der Ausführung des Befehls kannst du die SSH-Verbindung schließen.
 
 # Fazit
-Nun hast du Uptime Kuma erfolgreich installiert und das Tool so eingerichtet, dass es beim Hochfahren gestartet wird.  
+
+Nun hast du Uptime Kuma erfolgreich installiert und das Tool so eingerichtet, dass es beim Hochfahren gestartet wird.
 
 Deine Uptime Kuma-Instanz wird von nun an unter deiner Subdomain (z.B. `https://status.example.com`) verfügbar sein.
+
+Wenn du Uptime-Kuma updaten möchtest, kannst du dem Tutorial [Aktualisierung der Uptime Kuma Instanz](https://community.netcup.com/de/tutorials/update-uptime-kuma) folgen.  
+Wenn du Alerts einrichten möchtest, kannst du dem Tutorial [Konfigurieren von Echtzeit-Benachrichtigungen mit Uptime Kuma](https://community.netcup.com/de/tutorials/uptime-kuma-notification-setup) folgen.
 
 Vielen Dank für die Nutzung dieses Tutorials!
 
@@ -190,12 +212,13 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 # Contributor's Certificate of Origin
+
 By making a contribution to this project, I certify that:
 
- 1) The contribution was created in whole or in part by me and I have the right to submit it under the licence indicated in the file; or
+1.  The contribution was created in whole or in part by me and I have the right to submit it under the licence indicated in the file; or
 
- 2) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate licence and I have the right under that licence to submit that work with modifications, whether created in whole or in part by me, under the same licence (unless I am permitted to submit under a different licence), as indicated in the file; or
+2.  The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate licence and I have the right under that licence to submit that work with modifications, whether created in whole or in part by me, under the same licence (unless I am permitted to submit under a different licence), as indicated in the file; or
 
- 3) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+3.  The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
 
- 4) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the licence(s) involved.
+4.  I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the licence(s) involved.

--- a/community-tutorials/update-uptime-kuma/01-en.md
+++ b/community-tutorials/update-uptime-kuma/01-en.md
@@ -8,7 +8,8 @@ author_name: Konstantin Protzen
 author_url: https://github.com/cuzimbisonratte
 author_image: https://github.com/cuzimbisonratte.png
 author_bio:
-tags: [linux, ubuntu, uptime, monitoring, kuma, nodejs, nginx, update, up-to-date]
+tags:
+  [linux, ubuntu, uptime, monitoring, kuma, nodejs, nginx, update, up-to-date]
 netcup_product_url: https://www.netcup.de/bestellen/produkt.php?produkt=2991
 language: en
 available_languages: [en, de]
@@ -31,11 +32,11 @@ Also, I recommend that you backup your Uptime Kuma instance before updating it. 
 This tutorial will update your Uptime Kuma instance to version 1.22.1 BUT you need to check whether that is the [Latest Uptime Kuma Release](https://github.com/louislam/uptime-kuma/releases/latest) latest version and replace the version number in command #5 below with the latest version number.
 
 1. Log in to your server via SSH.
-2. Enter `sudo systemctl stop uptime-kuma` to stop the Uptime Kuma instance.
+2. Enter `sudo systemctl stop uptimekuma` to stop the Uptime Kuma instance.
 3. Enter your password and press `Enter`.
 4. Move into the Uptime Kuma directory with `cd uptime-kuma`.
 5. Enter `git fetch --all && git checkout 1.22.1 --force && npm install --production && npm run download-dist` to pull the latest changes from the Uptime Kuma repository - !! DO NOT FORGET TO REPLACE THE VERSION NUMBER WITH THE LATEST VERSION NUMBER !!
-6. Restart the Uptime Kuma service with `sudo systemctl start uptime-kuma`.
+6. Restart the Uptime Kuma service with `sudo systemctl start uptimekuma`.
 7. Enter `exit` to leave the SSH session.
 
 # Conclusion

--- a/community-tutorials/update-uptime-kuma/01-en.md
+++ b/community-tutorials/update-uptime-kuma/01-en.md
@@ -2,7 +2,7 @@
 title: Update Your Uptime Kuma Instance
 description: Learn how to update your Uptime Kuma instance.
 level: beginner
-updated_at: 2023-08-16
+updated_at: 2023-11-28
 slug: update-uptime-kuma
 author_name: Konstantin Protzen
 author_url: https://github.com/cuzimbisonratte

--- a/community-tutorials/update-uptime-kuma/02-de.md
+++ b/community-tutorials/update-uptime-kuma/02-de.md
@@ -2,7 +2,7 @@
 title: Aktualisierung der Uptime Kuma Instanz
 description: Lerne, wie du deine Uptime Kuma Instanz aktualisieren kannst.
 level: beginner
-updated_at: 2023-08-16
+updated_at: 2023-11-28
 slug: update-uptime-kuma
 author_name: Konstantin Protzen
 author_url: https://github.com/cuzimbisonratte

--- a/community-tutorials/update-uptime-kuma/02-de.md
+++ b/community-tutorials/update-uptime-kuma/02-de.md
@@ -8,7 +8,20 @@ author_name: Konstantin Protzen
 author_url: https://github.com/cuzimbisonratte
 author_image: https://github.com/cuzimbisonratte.png
 author_bio:
-tags: [linux, ubuntu, uptime, monitoring, kuma, nodejs, nginx, sicherung, wiederherstellung, update, up-to-date]
+tags:
+  [
+    linux,
+    ubuntu,
+    uptime,
+    monitoring,
+    kuma,
+    nodejs,
+    nginx,
+    sicherung,
+    wiederherstellung,
+    update,
+    up-to-date,
+  ]
 netcup_product_url: https://www.netcup.de/bestellen/produkt.php?produkt=2991
 language: de
 available_languages: [en, de]
@@ -35,7 +48,7 @@ Außerdem empfehle ich dir, eine Sicherung deiner Uptime Kuma Instanz zu erstell
 Dieses Tutorial aktualisiert deine Uptime Kuma Instanz auf Version 1.22.1, ABER bitte prüfe, welche die [neuste Version](https://github.com/louislam/uptime-kuma/releases/latest) ist und übernimm diese Versionsnummer in Punkt #5.
 
 1. Melde dich über SSH bei deinem Server an.
-2. Gib `sudo systemctl stop uptime-kuma` ein, um die Uptime Kuma Instanz zu stoppen.
+2. Gib `sudo systemctl stop uptimekuma` ein, um die Uptime Kuma Instanz zu stoppen.
 3. Gib dein Passwort ein und drücke `Enter`.
 4. Bewege dich in das Uptime Kuma Verzeichnis mit `cd uptime-kuma`.
 5. Gib `git fetch --all && git checkout 1.22.1 --force && npm install --production && npm run download-dist` ein, um die letzten Änderungen aus dem Uptime Kuma Repository zu ziehen - !! VERGISS NICHT DIE VERSIONSNUMMER MIT DER NEUESTEN VERSIONSNUMMER ZU ERSETZEN. !!


### PR DESCRIPTION
Updates:
- Main tutorial
    - Fix spacing
    - Update to use NVM because nodesource is deprecated
    - Update processes and systemd entries to use "uptimekuma" instead of "uptime-kuma"
    - Enable IPv6 listening in nginx config
    - Removed username-variables from service-files because fixed username is used in the tutorial
    - Merged firewall commands into one unified line
    - Add links to conclusion to other tutorials that use the installed Instance and work with
    - Rechecked installation process (updated last-checked date)
    - Updated last-updated HEAD variable
- Updating tutorial
    - Update processes and systemd entries to use "uptimekuma" instead of "uptime-kuma"
    - Updated last-updated HEAD variable