### PR TITLE
Deduplicate tutorials

### DIFF
--- a/community-tutorials/how-to-install-dockerized-nginx-with-mariadb/01-en.md
+++ b/community-tutorials/how-to-install-dockerized-nginx-with-mariadb/01-en.md
@@ -1,6 +1,6 @@
 ---
 title: How to Install Dockerized nginx with MariaDB
-description: This tutorial explains how to install docker and nginx with a mariaDB database in just a few minutes.
+description: This tutorial explains how to install Nginx Proxy Manager with a mariaDB database in just a few minutes using docker compose.
 level: [beginner]
 updated_at: 2023-04-19
 slug: how-to-install-dockerized-nginx-with-mariadb
@@ -16,48 +16,17 @@ available_languages: [en]
 
 # Introduction
 
-In this "how to" tutorial you are going to set up your own nginx instance with a mariaDB.
+In this "how to" tutorial you are going to set up your own Nginx Proxy Manager instance with a mariaDB.
 Nginx [engine x] is an HTTP and reverse proxy server, a mail proxy server, and a generic TCP/UDP proxy server, and as an open source project is free to use.
 
-First we are going to uninstall any old docker engine and install the latest (can be skipped), then we'll create/edit the docker-compose file, and check all the containers and the setup.
+First we'll create/edit the docker-compose file, and check all the containers and the setup.
 
 # Requirements
 
-- Docker
-- Docker Compose or docker-compose
+- Docker and Docker Compose or docker-compose ([Installation guide](/en/tutorials/how-to-install-the-latest-docker-engine-via-docker-script))
 - Linux server
 
-# Step 1 - Uninstall old Docker Engine, CLI, containerd, and Docker Compose packages
-
-``` bash
-sudo apt-get purge docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
-```
-
-# Step 2 - Curl the script for installation from docker
-
-``` bash
-curl -fsSL https://get.docker.com -o get-docker.sh
-```
-
-# Step 3 - Dry run the script to check for complications
-
-``` bash
-sudo sh ./get-docker.sh --dry-run
-```
-
-# Step 4 - Run the script
-
-``` bash
-sudo sh ./get-docker.sh
-```
-
-# Step 5 - Verify the installation
-
-``` bash
-docker --version
-```
-
-# Step 6 - Create a folder to save the docker-compose file and cd into that folder
+# Step 1 - Create a folder to save the docker-compose file and cd into that folder
 
 ``` bash
 mkdir nginx-with-postgres
@@ -67,10 +36,10 @@ mkdir nginx-with-postgres
 cd nginx-with-postgres
 ```
 
-# Step 7 - Copy the docker-compose file to your system
+# Step 2 - Copy the docker-compose file to your system
 
 ``` bash
-vim docker-compose.yml
+nano -ET 3 docker-compose.yml
 ```
 
 Paste the content inside this file.
@@ -135,15 +104,15 @@ networks:
 
 ```
 
-# Step 8 - Edit the docker-compose file
+# Step 3 - Edit the docker-compose file
 
 Edit the parts with 'changeMe.' and of course any other parts you want to modify, such as the ports exposed on the host machine.
 
-# Step 9 - Check the configuration
+# Step 4 - Check the configuration
 
 Make sure you have changed all the 'changeMe.' parts. Now you are good to go.
 
-# Step 10 - Create the containers
+# Step 5 - Create the containers
 
 With docker-compose, it's fairly easy to set everything up.
 
@@ -153,7 +122,7 @@ With docker-compose, it's fairly easy to set everything up.
 docker compose up -d
 ```
 
-# Step 11 - Check the containers
+# Step 6 - Check the containers
 
 Deployment should take a maximum of 2 minutes to be up and running as the app waits for the db and a successful health check.
 *Type:*
@@ -164,7 +133,7 @@ docker ps -a
 
 You should wait till the nginx-db container is up and healthy and the nginx-app is running.
 
-# Step 12 - Check the URL
+# Step 7 - Check the URL
 
 Now you can check your port 80 (or another port if you have changed the left side) with your browser at localhost:80, or serverIP:80 if you run it on a server in a different network or your provided URL inside the docker-compose file.
 
@@ -176,7 +145,7 @@ You can now access the server on the 81 port to open the admin panel and start c
 
 # Conclusion
 
-As you have seen, setting up nginx with its own db instance is quite simple and straightforward.
+As you have seen, setting up Nginx Proxy Manager with its own db instance is quite simple and straightforward.
 
 
 # License

--- a/community-tutorials/how-to-install-dockerized-onedev-with-postgres-database/01-en.md
+++ b/community-tutorials/how-to-install-dockerized-onedev-with-postgres-database/01-en.md
@@ -20,45 +20,14 @@ In this "how to" tutorial you are going to set up your own OneDev git server wit
 The server will contain a lot of extra features, such as symbol navigation and code search, customizable issue fields and workflow, visual editor for CI/CD pipeline files, service desk for customer support, and code annotation with static analysis results.
 And the best part is that it is easy to use, maintain and set up.
 
-First we are going to uninstall any old docker engine and install the latest (can be skipped), then we'll create/edit the docker-compose file, and check all the containers and the setup.
+First we'll create/edit the docker-compose file, and check all the containers and the setup.
 
 # Requirements
 
-- Docker
-- Docker Compose or docker-compose
+- Docker and Docker Compose or docker-compose ([Installation guide](/en/tutorials/how-to-install-the-latest-docker-engine-via-docker-script)) 
 - Linux server
 
-# Step 1 - Uninstall old Docker Engine, CLI, containerd, and Docker Compose packages
-
-``` bash
-sudo apt-get purge docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
-```
-
-# Step 2 - Curl the script for installation from docker
-
-``` bash
-curl -fsSL https://get.docker.com -o get-docker.sh
-```
-
-# Step 3 - Dry run the script to check for complications
-
-``` bash
-sudo sh ./get-docker.sh --dry-run
-```
-
-# Step 4 - Run the script
-
-``` bash
-sudo sh ./get-docker.sh
-```
-
-# Step 5 - Verify the installation
-
-``` bash
-docker --version
-```
-
-# Step 6 - Create a folder to save the docker-compose file and cd into that folder
+# Step 1 - Create a folder to save the docker-compose file and cd into that folder
 
 ``` bash
 mkdir onedev-with-postgres
@@ -68,10 +37,10 @@ mkdir onedev-with-postgres
 cd onedev-with-postgres
 ```
 
-# Step 7 - Copy the docker-compose file to your system
+# Step 2 - Copy the docker-compose file to your system
 
 ``` bash
-vim docker-compose.yml
+nano -ET3 docker-compose.yml
 ```
 
 Paste the content inside this file.
@@ -142,15 +111,15 @@ networks:
 
 ```
 
-# Step 8 - Edit the docker-compose file
+# Step 3 - Edit the docker-compose file
 
 Edit the parts with 'changeMe.' and of course any other parts you want to modify, such as the ports exposed on the host machine.
 
-# Step 9 - Check the configuration
+# Step 4 - Check the configuration
 
 Make sure you have changed all the 'changeMe.' parts. Now you are good to go.
 
-# Step 10 - Create the containers
+# Step 5 - Create the containers
 
 With docker-compose, it's fairly easy to set everything up.
 
@@ -160,7 +129,7 @@ With docker-compose, it's fairly easy to set everything up.
 docker compose up -d
 ```
 
-# Step 11 - Check the containers
+# Step 6 - Check the containers
 
 Deployment should take a maximum of 2 minutes to be up and running as the app waits for the db and a successful health check.
 
@@ -172,7 +141,7 @@ docker ps -a
 
 You should wait till the onedev-db container is up and healthy and the onedev-app is running.
 
-# Step 12 - Check the URL
+# Step 7 - Check the URL
 
 Now you can check your port 6610 (or another port if you have changed the left side) with your browser at localhost:6610, or serverIP:6610 if you run it on a server in a different network or your provided URL inside the docker-compose file.
 

--- a/community-tutorials/how-to-install-dockerized-sonarqube-with-postgres-database/01-en.md
+++ b/community-tutorials/how-to-install-dockerized-sonarqube-with-postgres-database/01-en.md
@@ -20,45 +20,14 @@ In this "how to" tutorial you are going to set up your SonarQube instance with d
 
 SonarQube is the leading tool for continuously inspecting the code quality and security of your codebases, and guiding development teams during code reviews. Covering 27 programming languages, while pairing-up with your existing software pipeline, SonarQube provides clear remediation guidance for developers to understand and fix issues, and for teams overall to deliver better and safer software. With over 225,000 deployments helping small development teams as well as global organizations, SonarQube provides the means for all teams and companies around the world to own and impact their code quality and security.
 
-First we are going to uninstall any old docker engine and install the latest (can be skipped), then we'll create/edit the docker-compose file, and check all the containers and the setup.
+First we'll create/edit the docker-compose file, and check all the containers and the setup.
 
 # Requirements
 
-- Docker
-- Docker Compose or docker-compose
+- Docker and Docker Compose or docker-compose ([Installation guide](/en/tutorials/how-to-install-the-latest-docker-engine-via-docker-script)) 
 - Linux server
 
-# Step 1 - Uninstall old Docker Engine, CLI, containerd, and Docker Compose packages
-
-``` bash
-sudo apt-get purge docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
-```
-
-# Step 2 - Curl the script for installation from docker
-
-``` bash
-curl -fsSL https://get.docker.com -o get-docker.sh
-```
-
-# Step 3 - Dry run the script to check for complications
-
-``` bash
-sudo sh ./get-docker.sh --dry-run
-```
-
-# Step 4 - Run the script
-
-``` bash
-sudo sh ./get-docker.sh
-```
-
-# Step 5 - Verify the installation
-
-``` bash
-docker --version
-```
-
-# Step 6 - Create a folder to save the docker-compose file and cd into that folder
+# Step 1 - Create a folder to save the docker-compose file and cd into that folder
 
 ``` bash
 mkdir sonarqube-with-postgres
@@ -68,10 +37,10 @@ mkdir sonarqube-with-postgres
 cd sonarqube-with-postgres
 ```
 
-# Step 7 - Copy the docker-compose file to your system
+# Step 2 - Copy the docker-compose file to your system
 
 ``` bash
-vim docker-compose.yml
+nano -ET3 docker-compose.yml
 ```
 
 Paste the content inside this file.
@@ -143,15 +112,15 @@ networks:
 
 ```
 
-# Step 8 - Edit the docker-compose file
+# Step 3 - Edit the docker-compose file
 
 Edit the parts with 'changeMe.' and of course any other parts you want to modify, such as the ports exposed on the host machine.
 
-# Step 9 - Check the configuration
+# Step 4 - Check the configuration
 
 Make sure you have changed all the 'changeMe.' parts. Now you are good to go.
 
-# Step 10 - Create the containers
+# Step 5 - Create the containers
 
 With docker-compose, it's fairly easy to set everything up.
 
@@ -161,7 +130,7 @@ With docker-compose, it's fairly easy to set everything up.
 docker compose up -d
 ```
 
-# Step 11 - Check the containers
+# Step 6 - Check the containers
 
 Deployment should take a maximum of 2 minutes to be up and running as the app waits for the db and a successful health check.
 
@@ -173,7 +142,7 @@ docker ps -a
 
 You should wait till the sonarqube-db container is up and healthy and the sonarqube-app is running.
 
-# Step 12 - Check the URL
+# Step 7 - Check the URL
 
 Now you can check your port 9000 (or another port if you have changed the left side) with your browser at localhost:9000, or serverIP:9000 if you run it on a server in a different network or your provided URL inside the docker-compose file.
 

--- a/community-tutorials/how-to-install-dockerized-synapse-admin/01-en.md
+++ b/community-tutorials/how-to-install-dockerized-synapse-admin/01-en.md
@@ -18,48 +18,15 @@ available_languages: [en]
 
 In this "how to" tutorial you are going to set up your own Synapse Admin instance.
 
-<here>
-
-First we are going to uninstall any old docker engine and install the latest (can be skipped), then we'll create/edit the docker-compose file, and check all the containers and the setup.
+First we'll create/edit the docker-compose file, and check all the containers and the setup.
 
 # Requirements
 
-- Docker
-- Docker Compose or docker-compose
+- Docker and Docker Compose or docker-compose ([Installation guide](/en/tutorials/how-to-install-the-latest-docker-engine-via-docker-script)) 
 - Linux server
 - Access to the following endpoints: /_matrix AND /_synapse/admin
 
-# Step 1 - Uninstall old Docker Engine, CLI, containerd, and Docker Compose packages
-
-``` bash
-sudo apt-get purge docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
-```
-
-# Step 2 - Curl the script for installation from docker
-
-``` bash
-curl -fsSL https://get.docker.com -o get-docker.sh
-```
-
-# Step 3 - Dry run the script to check for complications
-
-``` bash
-sudo sh ./get-docker.sh --dry-run
-```
-
-# Step 4 - Run the script
-
-``` bash
-sudo sh ./get-docker.sh
-```
-
-# Step 5 - Verify the installation
-
-``` bash
-docker --version
-```
-
-# Step 6 - Create a folder to save the docker-compose file and cd into that folder
+# Step 1 - Create a folder to save the docker-compose file and cd into that folder
 
 ``` bash
 mkdir synapse-admin
@@ -69,10 +36,10 @@ mkdir synapse-admin
 cd synapse-admin
 ```
 
-# Step 7 - Copy the docker-compose file to your system
+# Step 2 - Copy the docker-compose file to your system
 
 ``` bash
-vim docker-compose.yml
+nano -ET3 docker-compose.yml
 ```
 
 Paste the content inside this file.
@@ -107,15 +74,15 @@ networks:
 
 ```
 
-# Step 8 - Edit the docker-compose file
+# Step 3 - Edit the docker-compose file
 
 Edit the parts with 'changeMe.' and of course networks and any other parts you want to modify, such as the ports exposed on the host machine.
 
-# Step 9 - Check the configuration
+# Step 4 - Check the configuration
 
 Make sure that you have changed all the 'changeMe.' parts. Now you are good to go.
 
-# Step 10 - Create the containers
+# Step 5 - Create the containers
 
 With docker-compose, it's fairly easy to set everything up.
 
@@ -125,7 +92,7 @@ With docker-compose, it's fairly easy to set everything up.
 docker compose up -d
 ```
 
-# Step 11 - Check the containers
+# Step 6 - Check the containers
 
 Deployment should take a maximum of 2 minutes to be up and running.
 
@@ -135,7 +102,7 @@ Deployment should take a maximum of 2 minutes to be up and running.
 docker ps -a
 ```
 
-# Step 12 - Check the URL
+# Step 7 - Check the URL
 
 Now you can check your port 80 (or another port if you have changed the left side) with your browser at localhost:80, or serverIP:80 if you run it on a server in a different network or your provided URL inside the docker compose-file.
 

--- a/community-tutorials/how-to-install-the-latest-docker-engine-via-docker-script/01-en.md
+++ b/community-tutorials/how-to-install-the-latest-docker-engine-via-docker-script/01-en.md
@@ -8,7 +8,7 @@ author_name: Peter Mesiha
 author_url: https://github.com/MrReginaldKray
 author_image:
 author_bio:
-tags: [shell, ssh, linux, docker]
+tags: [shell, ssh, debian, linux, docker]
 netcup_product_url: https://www.netcup.de/bestellen/produkt.php?produkt=2884
 language: en
 available_languages: [en]
@@ -16,26 +16,36 @@ available_languages: [en]
 
 # Introduction
 
-This tutorial describes how to install the latest Docker Engine on your server.
+This tutorial describes how to install the latest Docker Engine on your debian/ubuntu server.
+This will use the official script on https://get.docker.com which adds the docker
+apt-repository and installs the required packages from there.
 
 # Requirements
 
-- Linux based server
+- Debian based server
+- curl or wget
+- sudo
 
 # Step 1 - Uninstall old Docker Engine, CLI, containerd, and Docker Compose packages
 
-``` bash
+```bash
 sudo apt-get purge docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
 ```
 
-``` bash
+```bash
 sudo apt-get update
 ```
 
-# Step 2 - Curl the script for installation from docker
+# Step 2 - Download the script for installation from docker
 
-``` bash
-curl -fsSL https://get.docker.com -o get-docker.sh
+```bash
+curl -fsS -o get-docker.sh  https://get.docker.com
+```
+
+or
+
+```bash
+wget -O get-docker.sh https://get.docker.com
 ```
 
 # Step 3 - Dry run the script to check for complications
@@ -46,11 +56,12 @@ sudo sh ./get-docker.sh --dry-run
 
 # Step 4 - Finally run the script
 
+This will install docker by adding their repository to a apt.
 ``` bash
 sudo sh ./get-docker.sh
 ```
 
-# Step 4 - Verify the installation
+# Step 5 - Verify the installation
 
 ``` bash
 docker --version


### PR DESCRIPTION
I don't like the tutorials, they are really useless. But information shouldn't be duplicated.
The nginx tutorial was really stupid. It installs [Nginx Proxy Manager](https://nginxproxymanager.com/) and that should be mentioned somewhere.
Level is `beginner` so I think nano is more appropriate.

I didn't fact-check the tutorials, but I'm not sure if they are any good at all. The docker one isn't completly stupid, but it should mention how the install script works, just running a random script as root (twice) is bad