### PR TITLE
Update 01-en.md for telegram_message_after_login

### DIFF
--- a/community-tutorials/telegram_message_after_login/01-en.md
+++ b/community-tutorials/telegram_message_after_login/01-en.md
@@ -3,19 +3,19 @@ title: Set up a Telegram Bot
 description: Learn how to receive a message via Telegram every time someone logs into your server.
 level: [beginner] 
 updated_at: 2022-12-13
-slug: get-message-after-login
+slug: telegram-message-after-login
 author_name: Michael Luckas
 author_url: https://github.com/extremmichi
 author_image: 
 author_bio: 
-tags: [shell, ssh, linux,message, login] 
+tags: [shell, ssh, linux, message, login] 
 netcup_product_url: https://www.netcup.eu/bestellen/produkt.php?produkt=2991
 language: en
 available_languages: [en]
 ---
 # Introduction
 
-In this tutorial you will learn how to set up a Telegram bot using the Telegram API. This will allow you to receive a message on Telegram after each login attempt on your server.
+In this tutorial you will learn how to set up a Telegram bot using the Telegram API. This will allow you to receive a message on Telegram after each login on your server.
 
 I am doing this on a Debian installation, but this process should also work on other Linux distributions.
 
@@ -27,7 +27,7 @@ You need a running vServer or Root Server from netcup with superuser access.
 ## Step 1 - Installing Telegram
 First, install Telegram on your smartphone and open the app.
 
-## Step 2  Creating the bot
+## Step 2 - Creating the bot
 Then search for the user "botfather" in the contacts.
 We create a new bot by sending "botfather" the following message:
 
@@ -35,10 +35,10 @@ We create a new bot by sending "botfather" the following message:
 
 "botfather" will ask for the name of the bot. You can choose any name you want, but note that the name must be unique. Next, choose a username. This must end with the suffix "_bot". 
 
-For example, I used these names:
+For example, I used this name / username combination:
 
-`Superduperbot for the bot
-Superduperbot_bot for the username`
+`Superduperbot` for the bot name
+`Superduperbot_bot` for the username
 
 "botfather" will now create the bot and generate a token. We will need this later, so write down the token.
 
@@ -46,21 +46,22 @@ Here is an example of how the token looks:
 
 `123456090:ABCDEFGHIJK-ABCDEFGHIJK`
 
-## Step 3 Configuring the bot
+## Step 3 - Configuring the bot
 
 Now, search for the newly created bot in your Telegram contacts. Next, start the bot by clicking on start or sending the message:
 
 `/start`
 
-Next, we point our Browser to the address shown below. Replace "TOKEN" with the token you got from "botfather" in the previous step:
+Also send at least one normal message to the bot, e.g. `foobar` to get an ID in the next step.
 
+Next, we point our browser to the address shown below. Replace "TOKEN" with the token you got from "botfather" in the previous step:
 
 `https://api.telegram.org/bot"TOKEN"/getUpdates`
      
-Write down the row of numbers coming after "id". This is our "Telegram_id" and will be needed in the next step.
+Write down the row of numbers coming after "id". This is our Telegram "ID" and will be needed in the next step.
 
      
-## Step 4 Creating the notification script
+## Step 4 - Creating the notification script
 
 Head over to your netcup server and create a script under "/etc/profile.d" named something like "telegram_message_on_login.sh" by running the command shown below. Note that any script in "/etc/profile.d" will be executed during each login to your server.
 
@@ -68,7 +69,8 @@ Head over to your netcup server and create a script under "/etc/profile.d" named
 
 Copy the following into the terminal window. Please replace the values under TOKEN and ID with your specific data:
 
-`#!/bin/bash
+```
+#!/bin/bash
 
     TOKEN="123456090:ABCDEFGHIJK-ABCDEFGHIJK"
     ID="123456789"
@@ -77,7 +79,8 @@ Copy the following into the terminal window. Please replace the values under TOK
     MESSAGE=" $USER logged in at  $DATE on $HOSTNAME !"
     URL="https://api.telegram.org/bot$TOKEN/sendMessage"
 
-    curl -s -X POST $URL -d chat_id=$ID -d text="$MESSAGE" >/dev/null`
+    curl -s -X POST $URL -d chat_id=$ID -d text="$MESSAGE" >/dev/null
+```
 
 Last, make the script executable by running this command:
 

--- a/community-tutorials/telegram_message_after_login/01-en.md
+++ b/community-tutorials/telegram_message_after_login/01-en.md
@@ -3,7 +3,7 @@ title: Set up a Telegram Bot
 description: Learn how to receive a message via Telegram every time someone logs into your server.
 level: [beginner] 
 updated_at: 2022-12-13
-slug: telegram-message-after-login
+slug: get-message-after-login
 author_name: Michael Luckas
 author_url: https://github.com/extremmichi
 author_image: 


### PR DESCRIPTION
Updated telegram_message_after_login because at least one normal message is needed to get an id response from the Telegram API. The single line Markdown quotes did not correctly display the code block and changed the headings into the same format `## Step X - Step X description`