### PR TITLE
Updated README.md fixing links to helpcenter and netcup forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you already have forked the community-tutorials repository, please make sure 
 ## Support
 If you need help with a specific tutorial, reach out to the contributor directly or join the netcup Forum for further questions, input and exchange.
 
-If you need help with something else than a tutorial, please make use of our [Help Center](helpcenter.netcup.com) or join the [netcup Forum](forum.netcup.de).
+If you need help with something else than a tutorial, please make use of our [Help Center](https://helpcenter.netcup.com) or join the [netcup Forum](https://forum.netcup.de).
 
 ## Authors and acknowledgement
 We want to thank our community for making this possible.


### PR DESCRIPTION
Fixed the links to Wiki helpcenter and netcup forum in the main README.md

Before the links pointed to:
https://github.com/netcup-community/community-tutorials/blob/main/helpcenter.netcup.com
and
https://github.com/netcup-community/community-tutorials/blob/main/forum.netcup.de
