### PR TITLE
Typo fixes in tutorial \install-web-server-mariadb-debian-php

### DIFF
--- a/community-tutorials/install-web-server-mariadb-debian-php/01-en.md
+++ b/community-tutorials/install-web-server-mariadb-debian-php/01-en.md
@@ -1,6 +1,6 @@
 ---
-title: Web Server (Apache) + PHP + MariaDB (MySQL) + Certbot + phpMyAdmin Tutotial on Debian
-description: Learn how to install a web server and Mariadb (MySQL) with phpMyAdmin on Debian servers
+title: Web Server (Apache) + PHP + MariaDB (MySQL) + Certbot + phpMyAdmin Tutorial on Debian
+description: Learn how to install a web server and MariaDB (MySQL) with phpMyAdmin on Debian servers
 updated_at: 2021-01-16
 slug: install-web-server-mariadb-debian-php
 author_name: Zoey Löchner
@@ -155,7 +155,7 @@ Now we have to configure PHP:
 - Press <kbd>CTRL + W</kbd> and <kbd>ENTER</kbd>: `memory_limit = 128M`.
   - Replace this line with `memory_limit = 1024M` or use more/less RAM (M = megabytes of RAM).<br>
 - Press <kbd>CTRL + W</kbd> and <kbd>ENTER</kbd>: `post_max_size = 8M`.
-  - Replace this line with `post_max_size = 10G`. This defines the maximum file size for uploading. You can set this value lower if you don't plan to upload 10-gigabyte files (for example, 100M for maximum 100 megabtye files). <br>
+  - Replace this line with `post_max_size = 10G`. This defines the maximum file size for uploading. You can set this value lower if you don't plan to upload 10-gigabyte files (for example, 100M for maximum 100 megabyte files). <br>
 - Press <kbd>CTRL + W</kbd> and <kbd>ENTER</kbd>: `upload_max_filesize = 2M`.
   - Replace this line with `upload_max_filesize = 10G`. This defines the maximum file size for uploading. You can set this value lower if you don't plan to upload 10-gigabyte files (for example, 100M for a maximum of 100-megabtye files). <br>
 - Press <kbd>CTRL + W</kbd> and <kbd>ENTER</kbd>: `;date.timezone =`.
@@ -183,7 +183,7 @@ add-apt-repository 'deb [arch=amd64,i386,arm64,ppc64el] https://mirror.netcologn
 apt install mariadb-server mariadb-client -y
 ```
 
-## Step 1.4.1 - Securing MariaDB
+### Step 1.4.1 - Securing MariaDB
 
 ```sh
 mysql_secure_installation
@@ -198,7 +198,7 @@ Press <kbd>y</kbd> <br>
 Press <kbd>y</kbd> <br>
 Press <kbd>y</kbd> <br>
 
-## Step 1.4.2 - Creating a user with root permissions on MariaDB
+### Step 1.4.2 - Creating a user with root permissions on MariaDB
 
 ```sh
 mysql -u root -p
@@ -264,8 +264,8 @@ For this change you need to regenerate the SSL certificate with `certbot certonl
 </VirtualHost>
 ```
 
-## Step 1.6 - Installing PHPMyAdmin (optional)
-Download and configure PHPMyAdmin:<br>
+## Step 1.6 - Installing phpMyAdmin (optional)
+Download and configure phpMyAdmin:<br>
 ```sh
 curl -L https://www.phpmyadmin.net/downloads/phpMyAdmin-latest-all-languages.zip -o phpmyadmin.zip
 unzip phpmyadmin.zip
@@ -293,8 +293,8 @@ $cfg['SaveDir'] = '';
 Save your changes by pressing <kbd>CTRL + X</kbd>, then <kbd>y</kbd> and finally by hitting <kbd>ENTER</kbd>. <br/> <br/>
 
 **Now you have two options:**
-- Create a new configuration for a new domain/subdomain (see Step 1.5) in which you want to use PHPMyAdmin (set `DocumentRoot /var/www/FOLDER` to `DocumentRoot /var/www/pma`). Then you can open PHPMyAdmin over this domain/subdomain. You are now finished with the installation of PHPMyAdmin. <br>
-- Or you open an existing configuration of an existing domain/subdomain (from Step 1.5) in which you want to use PHPMyAdmin (replace FILE.conf with the name of the configuration file of your domain/subdomain) - see below.
+- Create a new configuration for a new domain/subdomain (see Step 1.5) in which you want to use phpMyAdmin (set `DocumentRoot /var/www/FOLDER` to `DocumentRoot /var/www/pma`). Then you can open phpMyAdmin over this domain/subdomain. You are now finished with the installation of phpMyAdmin. <br>
+- Or you open an existing configuration of an existing domain/subdomain (from Step 1.5) in which you want to use phpMyAdmin (replace FILE.conf with the name of the configuration file of your domain/subdomain) - see below.
 
 ```sh
 nano /etc/apache2/sites-enabled/FILE.conf
@@ -359,7 +359,7 @@ exit;
 
 Now your user has been created and you can connect to the database via localhost.
 
-# Step 2 - Install additional  webservices
+# Step 2 - Install additional webservices
 
 Information on how to properly install additional webservices can be found in the following tutorials:
 


### PR DESCRIPTION
Fixed some typos and indentation in the English tutorial [install-web-server-mariadb-debian-php
Not taken care of is the broken author_image which could possibly be changed to the avatar of GitHub user Zoey2936 - https://avatars.githubusercontent.com/u/75573284?v=4